### PR TITLE
fix: eliminate race conditions in token mutations and OAuth handler replacement

### DIFF
--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -379,6 +379,10 @@ class ActronAirAPI:
     def _set_base_url(self, base_url: str, platform: str) -> None:
         """Update the base URL and platform, preserving existing authentication tokens.
 
+        Mutates the existing OAuth handler's endpoints in-place so that
+        coroutines holding a reference to ``self.oauth2_auth`` continue to
+        use the updated endpoints without observing a stale/replaced object.
+
         Args:
             base_url: New base URL to switch to
             platform: Platform identifier ('neo', 'que')
@@ -391,24 +395,9 @@ class ActronAirAPI:
         if self.base_url == base_url and self._platform == platform:
             return
 
-        # Preserve existing tokens
-        old_access_token = self.oauth2_auth.access_token
-        old_refresh_token = self.oauth2_auth.refresh_token
-        old_token_expiry = self.oauth2_auth.token_expiry
-        old_authenticated_platform = self.oauth2_auth.authenticated_platform
-
-        # Update base URL and platform, recreate OAuth2 handler to match new platform
         self.base_url = base_url
         self._platform = platform
-        self.oauth2_auth = ActronAirOAuth2DeviceCodeAuth(
-            base_url, self._oauth2_client_id, session=self._session
-        )
-
-        # Restore tokens
-        self.oauth2_auth.access_token = old_access_token
-        self.oauth2_auth.refresh_token = old_refresh_token
-        self.oauth2_auth.token_expiry = old_token_expiry
-        self.oauth2_auth.authenticated_platform = old_authenticated_platform
+        self.oauth2_auth.update_base_url(base_url)
 
     def _maybe_update_base_url_from_systems(self, systems: list[ActronAirSystemInfo]) -> None:
         """Automatically update base URL based on system types if auto-management is enabled.

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -392,12 +392,15 @@ class ActronAirAPI:
             incompatible platforms (Neo vs Que).
 
         """
+        base_url = base_url.strip().rstrip("/")
         if self.base_url == base_url and self._platform == platform:
             return
 
+        # Update OAuth endpoints first so a ValueError does not leave
+        # self.base_url / self._platform in a partially-updated state.
+        self.oauth2_auth.update_base_url(base_url)
         self.base_url = base_url
         self._platform = platform
-        self.oauth2_auth.update_base_url(base_url)
 
     def _maybe_update_base_url_from_systems(self, systems: list[ActronAirSystemInfo]) -> None:
         """Automatically update base URL based on system types if auto-management is enabled.

--- a/src/actron_neo_api/oauth.py
+++ b/src/actron_neo_api/oauth.py
@@ -54,7 +54,8 @@ class ActronAirOAuth2DeviceCodeAuth:
         if not client_id or not client_id.strip():
             raise ValueError("client_id cannot be empty")
 
-        self.base_url: str = base_url.rstrip("/")
+        base_url = base_url.strip().rstrip("/")
+        self.base_url: str = base_url
         self.client_id: Final[str] = client_id
         self.access_token: str | None = None
         self.refresh_token: str | None = None
@@ -119,7 +120,8 @@ class ActronAirOAuth2DeviceCodeAuth:
         if not base_url or not base_url.strip():
             raise ValueError("base_url cannot be empty")
 
-        self.base_url = base_url.rstrip("/")
+        base_url = base_url.strip().rstrip("/")
+        self.base_url = base_url
         self.token_url = f"{self.base_url}/api/v0/oauth/token"
         self.authorize_url = f"{self.base_url}/authorize"
         self.device_auth_url = f"{self.base_url}/connect"

--- a/src/actron_neo_api/oauth.py
+++ b/src/actron_neo_api/oauth.py
@@ -54,7 +54,7 @@ class ActronAirOAuth2DeviceCodeAuth:
         if not client_id or not client_id.strip():
             raise ValueError("client_id cannot be empty")
 
-        self.base_url: Final[str] = base_url.rstrip("/")
+        self.base_url: str = base_url.rstrip("/")
         self.client_id: Final[str] = client_id
         self.access_token: str | None = None
         self.refresh_token: str | None = None
@@ -65,10 +65,10 @@ class ActronAirOAuth2DeviceCodeAuth:
         self._token_lock: asyncio.Lock = asyncio.Lock()
 
         # OAuth2 endpoints
-        self.token_url: Final[str] = f"{self.base_url}/api/v0/oauth/token"
-        self.authorize_url: Final[str] = f"{self.base_url}/authorize"
-        self.device_auth_url: Final[str] = f"{self.base_url}/connect"
-        self.user_info_url: Final[str] = f"{self.base_url}/api/v0/client/account"
+        self.token_url: str = f"{self.base_url}/api/v0/oauth/token"
+        self.authorize_url: str = f"{self.base_url}/authorize"
+        self.device_auth_url: str = f"{self.base_url}/connect"
+        self.user_info_url: str = f"{self.base_url}/api/v0/client/account"
 
     @property
     def is_token_valid(self) -> bool:
@@ -101,6 +101,29 @@ class ActronAirOAuth2DeviceCodeAuth:
 
         """
         self._session = session
+
+    def update_base_url(self, base_url: str) -> None:
+        """Update the base URL and derived endpoints in-place.
+
+        Mutates the existing handler rather than requiring object
+        replacement, so coroutines that hold a reference to this instance
+        continue to see the updated endpoints.
+
+        Args:
+            base_url: New base URL for the Actron Air API
+
+        Raises:
+            ValueError: If base_url is empty
+
+        """
+        if not base_url or not base_url.strip():
+            raise ValueError("base_url cannot be empty")
+
+        self.base_url = base_url.rstrip("/")
+        self.token_url = f"{self.base_url}/api/v0/oauth/token"
+        self.authorize_url = f"{self.base_url}/authorize"
+        self.device_auth_url = f"{self.base_url}/connect"
+        self.user_info_url = f"{self.base_url}/api/v0/client/account"
 
     @contextlib.asynccontextmanager
     async def _get_session(self) -> AsyncIterator[aiohttp.ClientSession]:
@@ -447,6 +470,11 @@ class ActronAirOAuth2DeviceCodeAuth:
     ) -> None:
         """Set tokens manually (useful for restoring saved tokens).
 
+        This method is synchronous and performs all writes without yielding,
+        so it is safe within a single-threaded asyncio event loop.  For
+        thread-safe usage (e.g. from an executor), use :meth:`async_set_tokens`
+        which acquires ``_token_lock``.
+
         Args:
             access_token: The access token
             refresh_token: The refresh token (optional)
@@ -471,3 +499,29 @@ class ActronAirOAuth2DeviceCodeAuth:
         else:
             # No expiry known — force a refresh on next use
             self.token_expiry = None
+
+    async def async_set_tokens(
+        self,
+        access_token: str,
+        refresh_token: str | None = None,
+        expires_in: int | None = None,
+        token_type: str = "Bearer",
+    ) -> None:
+        """Set tokens under ``_token_lock`` for thread-safe usage.
+
+        Acquires the token lock before delegating to :meth:`set_tokens`.
+        Prefer this method when calling from a concurrent context or
+        off the event-loop thread.
+
+        Args:
+            access_token: The access token
+            refresh_token: The refresh token (optional)
+            expires_in: Token expiration time in seconds from now (optional)
+            token_type: Token type (default: "Bearer")
+
+        Raises:
+            ValueError: If access_token is empty or expires_in is negative
+
+        """
+        async with self._token_lock:
+            self.set_tokens(access_token, refresh_token, expires_in, token_type)

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -93,6 +93,16 @@ class TestActronAirAPIPlatformManagement:
         assert api.oauth2_auth.refresh_token == "old_refresh"
         assert api.oauth2_auth.token_expiry == 1234567890.0
 
+    def test_set_base_url_preserves_handler_identity(self) -> None:
+        """Test that _set_base_url mutates in-place, not replaces."""
+        api = ActronAirAPI(platform="neo")
+        original_oauth = api.oauth2_auth
+
+        api._set_base_url("https://que.actronair.com.au", "que")
+
+        assert api.oauth2_auth is original_oauth
+        assert api.oauth2_auth.base_url == "https://que.actronair.com.au"
+
     def test_set_base_url_no_change(self) -> None:
         """Test no-op when setting same URL."""
         api = ActronAirAPI(platform="neo")
@@ -919,8 +929,8 @@ class TestActronAirAPIInjectableSession:
         # Verify the external session was used
         external_session.request.assert_called_once()
 
-    def test_set_base_url_passes_session_to_new_oauth(self) -> None:
-        """Test _set_base_url passes session to recreated OAuth handler."""
+    def test_set_base_url_preserves_session(self) -> None:
+        """Test _set_base_url preserves session on in-place mutation."""
         from unittest.mock import MagicMock
 
         external_session = MagicMock()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1083,3 +1083,77 @@ class TestOAuthClientErrorWrapping:
 
         with pytest.raises(ActronAirAuthError, match="User info request failed"):
             await auth.get_user_info()
+
+
+class TestUpdateBaseUrl:
+    """Test update_base_url in-place mutation."""
+
+    def test_update_base_url(self) -> None:
+        """update_base_url changes all endpoint URLs in-place."""
+        auth = ActronAirOAuth2DeviceCodeAuth("https://old.example.com", "client")
+
+        auth.update_base_url("https://new.example.com")
+
+        assert auth.base_url == "https://new.example.com"
+        assert auth.token_url == "https://new.example.com/api/v0/oauth/token"
+        assert auth.authorize_url == "https://new.example.com/authorize"
+        assert auth.device_auth_url == "https://new.example.com/connect"
+        assert auth.user_info_url == "https://new.example.com/api/v0/client/account"
+
+    def test_update_base_url_preserves_tokens(self) -> None:
+        """update_base_url does not touch token fields."""
+        auth = ActronAirOAuth2DeviceCodeAuth("https://old.example.com", "client")
+        auth.set_tokens("tok123", "ref456", expires_in=3600)
+
+        auth.update_base_url("https://new.example.com")
+
+        assert auth.access_token == "tok123"
+        assert auth.refresh_token == "ref456"
+        assert auth.is_token_valid
+
+    def test_update_base_url_strips_trailing_slash(self) -> None:
+        """update_base_url strips trailing slash from URL."""
+        auth = ActronAirOAuth2DeviceCodeAuth("https://old.example.com", "client")
+
+        auth.update_base_url("https://new.example.com/")
+
+        assert auth.base_url == "https://new.example.com"
+
+    def test_update_base_url_empty_raises(self) -> None:
+        """update_base_url raises ValueError for empty URL."""
+        auth = ActronAirOAuth2DeviceCodeAuth("https://old.example.com", "client")
+
+        with pytest.raises(ValueError, match="base_url cannot be empty"):
+            auth.update_base_url("")
+
+    def test_update_base_url_preserves_identity(self) -> None:
+        """update_base_url mutates the same object, not a replacement."""
+        auth = ActronAirOAuth2DeviceCodeAuth("https://old.example.com", "client")
+        original_id = id(auth)
+
+        auth.update_base_url("https://new.example.com")
+
+        assert id(auth) == original_id
+
+
+class TestAsyncSetTokens:
+    """Test async_set_tokens thread-safe wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_async_set_tokens(self) -> None:
+        """async_set_tokens sets all token fields under lock."""
+        auth = ActronAirOAuth2DeviceCodeAuth("https://example.com", "client")
+
+        await auth.async_set_tokens("tok", "ref", expires_in=3600, token_type="Bearer")
+
+        assert auth.access_token == "tok"
+        assert auth.refresh_token == "ref"
+        assert auth.is_token_valid
+
+    @pytest.mark.asyncio
+    async def test_async_set_tokens_validation(self) -> None:
+        """async_set_tokens propagates ValueError from set_tokens."""
+        auth = ActronAirOAuth2DeviceCodeAuth("https://example.com", "client")
+
+        with pytest.raises(ValueError, match="access_token cannot be empty"):
+            await auth.async_set_tokens("")


### PR DESCRIPTION
## Summary

Eliminates two race conditions around token/OAuth state that could cause concurrent coroutines to observe partially-updated credentials.

Closes #50

## Problem

### 1. OAuth handler replaced without synchronization
`_set_base_url` in `actron.py` created a new `ActronAirOAuth2DeviceCodeAuth` instance and assigned it to `self.oauth2_auth`. Coroutines that captured a reference to the old handler before the replacement would continue using the stale object with outdated endpoints.

### 2. `set_tokens` mutates without `_token_lock`
`set_tokens()` writes 4 token fields without holding `_token_lock`, while `ensure_token_valid` reads those fields under the lock. In a multi-threaded context (e.g., Home Assistant executor), this could lead to partially-observed token state.

## Changes

### `src/actron_neo_api/oauth.py`
- Removed `Final` annotations from `base_url` and endpoint URL fields so they can be mutated in-place
- Added `update_base_url(base_url)` — mutates endpoint URLs on the existing handler object
- Added `async_set_tokens(...)` — acquires `_token_lock` before delegating to `set_tokens()` for thread-safe usage
- Updated `set_tokens` docstring to document thread-safety characteristics

### `src/actron_neo_api/actron.py`
- `_set_base_url` now calls `oauth2_auth.update_base_url()` instead of replacing the handler object
- Removed token save/restore bookkeeping (no longer needed)
- Updated docstring to reflect in-place mutation

### Tests
- `test_set_base_url_preserves_handler_identity` — verifies same object after URL change
- `test_set_base_url_preserves_session` — renamed from old test, verifies session survives
- `TestUpdateBaseUrl` — 5 tests covering URL mutation, token preservation, trailing slash, empty URL, identity
- `TestAsyncSetTokens` — 2 tests covering locked token setting and validation

## Testing

- All 430 tests pass
- 100% code coverage maintained
- All pre-commit checks pass