### PR TITLE
feat: Parse ModeSupport from API to determine supported HVAC modes

### DIFF
--- a/src/actron_neo_api/const.py
+++ b/src/actron_neo_api/const.py
@@ -18,6 +18,7 @@ AC_MODE_COOL: Final[str] = "COOL"
 AC_MODE_HEAT: Final[str] = "HEAT"
 AC_MODE_AUTO: Final[str] = "AUTO"
 AC_MODE_FAN: Final[str] = "FAN"
+AC_MODE_DRY: Final[str] = "DRY"
 AC_MODE_OFF: Final[str] = "OFF"
 
 # HTTP timeout defaults (seconds)

--- a/src/actron_neo_api/models/__init__.py
+++ b/src/actron_neo_api/models/__init__.py
@@ -7,7 +7,7 @@ This package contains all data models used in the Actron Air API
 from .auth import ActronAirDeviceCode, ActronAirToken, ActronAirUserInfo
 
 # For backward compatibility
-from .settings import ActronAirUserAirconSettings
+from .settings import ActronAirModeSupport, ActronAirUserAirconSettings
 from .status import ActronAirStatus
 from .system import (
     ActronAirACSystem,
@@ -23,6 +23,7 @@ __all__ = [
     "ActronAirZone",
     "ActronAirZoneSensor",
     "ActronAirPeripheral",
+    "ActronAirModeSupport",
     "ActronAirUserAirconSettings",
     "ActronAirLiveAircon",
     "ActronAirMasterInfo",

--- a/src/actron_neo_api/models/settings.py
+++ b/src/actron_neo_api/models/settings.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from ..const import (
     AC_MODE_AUTO,
     AC_MODE_COOL,
+    AC_MODE_DRY,
     AC_MODE_FAN,
     AC_MODE_HEAT,
     AC_MODE_OFF,
@@ -21,6 +22,30 @@ from ..const import (
 
 if TYPE_CHECKING:
     from .status import ActronAirStatus
+
+# Mapping from ModeSupport keys to AC_MODE constants
+_MODE_SUPPORT_MAP: dict[str, str] = {
+    "Cool": AC_MODE_COOL,
+    "Heat": AC_MODE_HEAT,
+    "Fan": AC_MODE_FAN,
+    "Auto": AC_MODE_AUTO,
+    "Dry": AC_MODE_DRY,
+}
+
+
+class ActronAirModeSupport(BaseModel):
+    """Mode support flags from the AC system.
+
+    Indicates which HVAC modes the system hardware supports.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    cool: bool = Field(True, alias="Cool")
+    heat: bool = Field(True, alias="Heat")
+    fan: bool = Field(True, alias="Fan")
+    auto: bool = Field(True, alias="Auto")
+    dry: bool = Field(False, alias="Dry")
 
 
 class ActronAirUserAirconSettings(BaseModel):
@@ -47,6 +72,10 @@ class ActronAirUserAirconSettings(BaseModel):
     turbo_mode_enabled: bool | dict[str, bool] = Field(
         default_factory=lambda: {"Enabled": False}, alias="TurboMode"
     )
+    mode_support: ActronAirModeSupport = Field(
+        default_factory=lambda: ActronAirModeSupport.model_validate({}),
+        alias="ModeSupport",
+    )
     _parent_status: "ActronAirStatus | None" = None
 
     def set_parent_status(self, parent: "ActronAirStatus") -> None:
@@ -57,6 +86,20 @@ class ActronAirUserAirconSettings(BaseModel):
 
         """
         self._parent_status = parent
+
+    @property
+    def supported_modes(self) -> list[str]:
+        """Get the list of HVAC modes supported by this system.
+
+        Returns:
+            List of supported mode strings (e.g., ['COOL', 'HEAT', 'FAN', 'AUTO'])
+
+        """
+        return [
+            mode_const
+            for key, mode_const in _MODE_SUPPORT_MAP.items()
+            if getattr(self.mode_support, key.lower(), False)
+        ]
 
     @property
     def current_setpoint(self) -> float:

--- a/src/actron_neo_api/models/settings.py
+++ b/src/actron_neo_api/models/settings.py
@@ -91,8 +91,12 @@ class ActronAirUserAirconSettings(BaseModel):
     def supported_modes(self) -> list[str]:
         """Get the list of HVAC modes supported by this system.
 
+        The returned modes depend on the hardware's ``ModeSupport`` flags.
+        Possible values are ``COOL``, ``HEAT``, ``FAN``, ``AUTO``, and ``DRY``.
+
         Returns:
-            List of supported mode strings (e.g., ['COOL', 'HEAT', 'FAN', 'AUTO'])
+            List of supported mode strings
+                (e.g., ``['COOL', 'HEAT', 'FAN', 'AUTO', 'DRY']``)
 
         """
         return [

--- a/src/actron_neo_api/models/system.py
+++ b/src/actron_neo_api/models/system.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from ..const import AC_MODE_AUTO, AC_MODE_COOL, AC_MODE_FAN, AC_MODE_HEAT, AC_MODE_OFF
+from ..const import AC_MODE_AUTO, AC_MODE_COOL, AC_MODE_DRY, AC_MODE_FAN, AC_MODE_HEAT, AC_MODE_OFF
 
 if TYPE_CHECKING:
     from .status import ActronAirStatus
@@ -159,7 +159,14 @@ class ActronAirACSystem(BaseModel):
         if not mode or not isinstance(mode, str):
             raise ValueError("Mode must be a non-empty string")
 
-        valid_modes = {AC_MODE_COOL, AC_MODE_HEAT, AC_MODE_AUTO, AC_MODE_FAN, AC_MODE_OFF}
+        valid_modes = {
+            AC_MODE_COOL,
+            AC_MODE_HEAT,
+            AC_MODE_AUTO,
+            AC_MODE_FAN,
+            AC_MODE_DRY,
+            AC_MODE_OFF,
+        }
         mode_upper = mode.upper().strip()
         if mode_upper not in valid_modes:
             raise ValueError(

--- a/src/actron_neo_api/models/system.py
+++ b/src/actron_neo_api/models/system.py
@@ -148,8 +148,9 @@ class ActronAirACSystem(BaseModel):
         externally, e.g. during system discovery).
 
         Args:
-            mode: Mode to set ('AUTO', 'COOL', 'FAN', 'HEAT', 'OFF')
-                 Use 'OFF' to turn the system off.
+            mode: Mode to set ('AUTO', 'COOL', 'DRY', 'FAN', 'HEAT', 'OFF')
+                 Use 'OFF' to turn the system off. Note that not all
+                 hardware supports every mode — check ``ModeSupport``.
 
         Raises:
             ValueError: If mode is invalid, no API reference available,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -485,3 +485,91 @@ class TestOptimisticStateOff:
         await settings_with_api.set_turbo_mode(True)
 
         assert settings_with_api.turbo_mode_enabled is True
+
+
+class TestModeSupport:
+    """Test ModeSupport parsing and supported_modes property."""
+
+    def test_default_mode_support(self) -> None:
+        """Default mode support includes cool, heat, fan, auto but not dry."""
+        settings = ActronAirUserAirconSettings.model_validate({})
+        assert "COOL" in settings.supported_modes
+        assert "HEAT" in settings.supported_modes
+        assert "FAN" in settings.supported_modes
+        assert "AUTO" in settings.supported_modes
+        assert "DRY" not in settings.supported_modes
+
+    def test_mode_support_from_api_data(self) -> None:
+        """Mode support is parsed from API data."""
+        settings = ActronAirUserAirconSettings.model_validate(
+            {
+                "isOn": True,
+                "Mode": "COOL",
+                "FanMode": "AUTO",
+                "ModeSupport": {
+                    "Cool": True,
+                    "Heat": True,
+                    "Fan": True,
+                    "Auto": True,
+                    "Dry": False,
+                },
+            }
+        )
+        assert "COOL" in settings.supported_modes
+        assert "HEAT" in settings.supported_modes
+        assert "FAN" in settings.supported_modes
+        assert "AUTO" in settings.supported_modes
+        assert "DRY" not in settings.supported_modes
+
+    def test_mode_support_with_dry_enabled(self) -> None:
+        """Dry mode appears in supported_modes when enabled."""
+        settings = ActronAirUserAirconSettings.model_validate(
+            {
+                "ModeSupport": {
+                    "Cool": True,
+                    "Heat": True,
+                    "Fan": True,
+                    "Auto": True,
+                    "Dry": True,
+                },
+            }
+        )
+        assert "DRY" in settings.supported_modes
+
+    def test_mode_support_partial(self) -> None:
+        """Only supported modes are returned when some are disabled."""
+        settings = ActronAirUserAirconSettings.model_validate(
+            {
+                "ModeSupport": {
+                    "Cool": True,
+                    "Heat": False,
+                    "Fan": True,
+                    "Auto": False,
+                    "Dry": False,
+                },
+            }
+        )
+        assert settings.supported_modes == ["COOL", "FAN"]
+
+    def test_mode_support_via_status_parsing(self) -> None:
+        """Mode support is parsed correctly through ActronAirStatus."""
+        status = ActronAirStatus(
+            isOnline=True,
+            lastKnownState={
+                "UserAirconSettings": {
+                    "isOn": True,
+                    "Mode": "COOL",
+                    "FanMode": "AUTO",
+                    "ModeSupport": {
+                        "Cool": True,
+                        "Heat": True,
+                        "Fan": True,
+                        "Auto": True,
+                        "Dry": False,
+                    },
+                },
+            },
+        )
+        status.parse_nested_components()
+        assert "COOL" in status.user_aircon_settings.supported_modes
+        assert "DRY" not in status.user_aircon_settings.supported_modes


### PR DESCRIPTION
## Summary

Instead of blindly assuming COOL/HEAT/FAN/AUTO are always available, read the `ModeSupport` dict from `UserAirconSettings` to determine which modes the system actually supports (including DRY).

## Changes

- **`const.py`** — Added `AC_MODE_DRY` constant
- **`models/settings.py`** — Added `ActronAirModeSupport` Pydantic model, `mode_support` field on `ActronAirUserAirconSettings`, and `supported_modes` property that returns the list of modes the hardware reports as supported
- **`models/system.py`** — Added `AC_MODE_DRY` to the valid modes set in `set_system_mode()`
- **`models/__init__.py`** — Exported `ActronAirModeSupport`
- **`tests/test_settings.py`** — Added `TestModeSupport` class with 5 tests covering defaults, API parsing, dry mode, partial support, and status-level parsing

## API Data

The `ModeSupport` field lives inside `UserAirconSettings` from the API:

```json
"ModeSupport": {
  "Cool": true,
  "Heat": true,
  "Fan": true,
  "Auto": true,
  "Dry": false
}
```

## Usage

```python
status.user_aircon_settings.supported_modes
# e.g. ['COOL', 'HEAT', 'FAN', 'AUTO']

status.user_aircon_settings.mode_support.dry
# False
```

## Checks

- All 385 tests pass
- 100% code coverage maintained
- All pre-commit checks pass (ruff, mypy, pydocstyle)