### PR TITLE
feat: Add zone capability fields (VAV, ITC, ITD, IHD, IAC)

### DIFF
--- a/src/actron_neo_api/models/zone.py
+++ b/src/actron_neo_api/models/zone.py
@@ -144,6 +144,11 @@ class ActronAirZone(BaseModel):
     temperature_setpoint_cool_c: float = Field(0.0, alias="TemperatureSetpoint_Cool_oC")
     temperature_setpoint_heat_c: float = Field(0.0, alias="TemperatureSetpoint_Heat_oC")
     sensors: dict[str, ActronAirZoneSensor] = Field(default_factory=dict, alias="Sensors")
+    variable_air_volume: bool = Field(False, alias="NV_VAV")
+    individual_temperature_control: bool = Field(False, alias="NV_ITC")
+    individual_temperature_deadband: bool = Field(False, alias="NV_ITD")
+    integrated_humidity_tracking: bool = Field(False, alias="NV_IHD")
+    indoor_air_compensation: bool = Field(False, alias="NV_IAC")
     zone_id: int
     _parent_status: "ActronAirStatus | None" = None
 

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -569,3 +569,65 @@ class TestZoneSensorAliasParsing:
         """signal_strength defaults to 'NA' when not in data."""
         sensor = ActronAirZoneSensor.model_validate({})
         assert sensor.signal_strength == "NA"
+
+
+class TestZoneCapabilityFields:
+    """Test zone capability fields parse from API aliases correctly."""
+
+    @staticmethod
+    def _make_zone(zone_data: dict[str, Any]) -> ActronAirZone:
+        """Create a zone with the given RemoteZoneInfo data."""
+        status = ActronAirStatus(
+            isOnline=True,
+            lastKnownState={
+                "UserAirconSettings": {
+                    "isOn": True,
+                    "Mode": "COOL",
+                    "EnabledZones": [True],
+                },
+                "RemoteZoneInfo": [zone_data],
+            },
+        )
+        return status.remote_zone_info[0]
+
+    def test_capabilities_parse_from_aliases(self) -> None:
+        """Zone capability fields parse from their NV_ aliases."""
+        zone = self._make_zone(
+            {
+                "LiveTemp_oC": 22.0,
+                "CanOperate": True,
+                "NV_VAV": True,
+                "NV_ITC": True,
+                "NV_ITD": True,
+                "NV_IHD": True,
+                "NV_IAC": True,
+            }
+        )
+        assert zone.variable_air_volume is True
+        assert zone.individual_temperature_control is True
+        assert zone.individual_temperature_deadband is True
+        assert zone.integrated_humidity_tracking is True
+        assert zone.indoor_air_compensation is True
+
+    def test_capabilities_default_to_false(self) -> None:
+        """Zone capability fields default to False when not present."""
+        zone = self._make_zone({"LiveTemp_oC": 22.0, "CanOperate": True})
+        assert zone.variable_air_volume is False
+        assert zone.individual_temperature_control is False
+        assert zone.individual_temperature_deadband is False
+        assert zone.integrated_humidity_tracking is False
+        assert zone.indoor_air_compensation is False
+
+    def test_mixed_capabilities(self) -> None:
+        """Capabilities can be independently set."""
+        zone = self._make_zone(
+            {
+                "LiveTemp_oC": 22.0,
+                "CanOperate": True,
+                "NV_IHD": True,
+                "NV_VAV": False,
+            }
+        )
+        assert zone.variable_air_volume is False
+        assert zone.individual_temperature_control is False
+        assert zone.integrated_humidity_tracking is True


### PR DESCRIPTION
## Summary

Expose zone-level capability flags from the API on `ActronAirZone` so Home Assistant (and other integrations) can determine what each zone supports.

## New Fields on `ActronAirZone`

| Field | API Alias | Description |
|---|---|---|
| `variable_air_volume` | `NV_VAV` | Whether the damper can modulate air flow (open/close vs variable) |
| `individual_temperature_control` | `NV_ITC` | Zones with `False` should not allow temp changes |
| `individual_temperature_deadband` | `NV_ITD` | Individual temperature deadband support |
| `integrated_humidity_tracking` | `NV_IHD` | Zones without this follow the main zone's humidity sensor |
| `indoor_air_compensation` | `NV_IAC` | Indoor air compensation support |

All fields default to `False` when not present in the API response.

## Tests

- `test_capabilities_parse_from_aliases` — verifies all five fields parse from their `NV_` aliases
- `test_capabilities_default_to_false` — verifies defaults when data is absent
- `test_mixed_capabilities` — verifies fields are independent

## Checklist

- [x] All tests pass (383 passed)
- [x] 100% code coverage maintained
- [x] All pre-commit checks pass (ruff, mypy, pydocstyle, etc.)
