### PR TITLE
chore: Remove empty models/base.py placeholder module

### DIFF
--- a/src/actron_neo_api/models/base.py
+++ b/src/actron_neo_api/models/base.py
@@ -1,1 +1,0 @@
-"""Base models and functionality for Actron Air API."""


### PR DESCRIPTION
## Summary

Removes the empty `src/actron_neo_api/models/base.py` placeholder module which contained only a docstring with no actual code and was not imported by any other module.

Closes #55

## Checklist

- [x] Verified `base.py` has no imports anywhere in the codebase
- [x] All 388 tests pass
- [x] 100% code coverage maintained
- [x] All pre-commit checks pass