### PR TITLE
refactor: Make command builders private across all models

### DIFF
--- a/src/actron_neo_api/models/system.py
+++ b/src/actron_neo_api/models/system.py
@@ -135,6 +135,24 @@ class ActronAirACSystem(BaseModel):
         """
         self._parent_status = parent
 
+    def _set_system_mode_command(self, mode_upper: str) -> dict[str, Any]:
+        """Build command dict for setting the system mode.
+
+        Args:
+            mode_upper: Validated, upper-cased mode string
+
+        Returns:
+            Command dictionary ready for ``send_command``
+
+        """
+        is_on = mode_upper != AC_MODE_OFF
+        command: dict[str, Any] = {
+            "command": {"UserAirconSettings.isOn": is_on, "type": "set-settings"}
+        }
+        if is_on:
+            command["command"]["UserAirconSettings.Mode"] = mode_upper
+        return command
+
     async def set_system_mode(self, mode: str) -> None:
         """Set the system mode for this AC unit.
 
@@ -183,17 +201,12 @@ class ActronAirACSystem(BaseModel):
         if not serial:
             raise ValueError("No serial number available")
 
-        # Determine if system should be on or off based on mode
-        is_on = mode_upper != AC_MODE_OFF
-
-        command = {"command": {"UserAirconSettings.isOn": is_on, "type": "set-settings"}}
-
-        if is_on:
-            command["command"]["UserAirconSettings.Mode"] = mode_upper
+        command = self._set_system_mode_command(mode_upper)
 
         await self._parent_status.api.send_command(serial, command)
 
         # Optimistic local state update
+        is_on = mode_upper != AC_MODE_OFF
         if is_on:
             self._parent_status.user_aircon_settings.is_on = True
             self._parent_status.user_aircon_settings.mode = mode_upper

--- a/src/actron_neo_api/models/zone.py
+++ b/src/actron_neo_api/models/zone.py
@@ -245,7 +245,7 @@ class ActronAirZone(BaseModel):
         return max(limit, target - variance)
 
     # Command generation methods
-    def set_temperature_command(self, temperature: float) -> dict[str, Any]:
+    def _set_temperature_command(self, temperature: float) -> dict[str, Any]:
         """Create a command to set temperature for this zone based on the current AC mode.
 
         Args:
@@ -290,7 +290,7 @@ class ActronAirZone(BaseModel):
 
         return {"command": command}
 
-    def set_enable_command(self, is_enabled: bool) -> dict[str, Any]:
+    def _set_enable_command(self, is_enabled: bool) -> dict[str, Any]:
         """Create a command to enable or disable this zone.
 
         Args:
@@ -351,7 +351,7 @@ class ActronAirZone(BaseModel):
         # Ensure temperature is within valid range for this zone
         temperature = max(self.min_temp, min(self.max_temp, temperature))
 
-        command = self.set_temperature_command(temperature)
+        command = self._set_temperature_command(temperature)
         if self.parent_status.api and self.parent_status.serial_number:
             # Capture optimistic values before await to avoid races
             settings = self.parent_status.user_aircon_settings
@@ -390,7 +390,7 @@ class ActronAirZone(BaseModel):
             is_enabled: True to enable, False to disable
 
         """
-        command = self.set_enable_command(is_enabled)
+        command = self._set_enable_command(is_enabled)
         if self.parent_status.api and self.parent_status.serial_number:
             await self.parent_status.api.send_command(self.parent_status.serial_number, command)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -267,29 +267,29 @@ class TestZoneCommands:
     """Test ActronAirZone command generation."""
 
     def test_set_temperature_command_cool(self) -> None:
-        """Test set_temperature_command in COOL mode."""
+        """Test _set_temperature_command in COOL mode."""
         zone = ActronAirZone(zone_id=0)
         parent = MagicMock()
         parent.user_aircon_settings.mode = "COOL"
         zone.set_parent_status(parent)
 
-        command = zone.set_temperature_command(22.0)
+        command = zone._set_temperature_command(22.0)
 
         assert command["command"]["RemoteZoneInfo[0].TemperatureSetpoint_Cool_oC"] == 22.0
 
     def test_set_temperature_command_heat(self) -> None:
-        """Test set_temperature_command in HEAT mode."""
+        """Test _set_temperature_command in HEAT mode."""
         zone = ActronAirZone(zone_id=1)
         parent = MagicMock()
         parent.user_aircon_settings.mode = "HEAT"
         zone.set_parent_status(parent)
 
-        command = zone.set_temperature_command(20.0)
+        command = zone._set_temperature_command(20.0)
 
         assert command["command"]["RemoteZoneInfo[1].TemperatureSetpoint_Heat_oC"] == 20.0
 
     def test_set_temperature_command_auto(self) -> None:
-        """Test set_temperature_command in AUTO mode."""
+        """Test _set_temperature_command in AUTO mode."""
         zone = ActronAirZone(zone_id=0)
         parent = MagicMock()
         parent.user_aircon_settings.mode = "AUTO"
@@ -297,49 +297,49 @@ class TestZoneCommands:
         parent.user_aircon_settings.temperature_setpoint_heat_c = 20.0
         zone.set_parent_status(parent)
 
-        command = zone.set_temperature_command(25.0)
+        command = zone._set_temperature_command(25.0)
 
         assert command["command"]["RemoteZoneInfo[0].TemperatureSetpoint_Cool_oC"] == 25.0
         assert command["command"]["RemoteZoneInfo[0].TemperatureSetpoint_Heat_oC"] == 21.0
 
     def test_set_temperature_command_no_parent(self) -> None:
-        """Test set_temperature_command without parent raises error."""
+        """Test _set_temperature_command without parent raises error."""
         zone = ActronAirZone(zone_id=0)
 
         with pytest.raises(RuntimeError, match="Zone must be attached to a parent status"):
-            zone.set_temperature_command(22.0)
+            zone._set_temperature_command(22.0)
 
     def test_set_enable_command_enable(self) -> None:
-        """Test set_enable_command to enable zone."""
+        """Test _set_enable_command to enable zone."""
         zone = ActronAirZone(zone_id=0)
         parent = MagicMock()
         parent.user_aircon_settings.enabled_zones = [False, True, False]
         zone.set_parent_status(parent)
 
-        command = zone.set_enable_command(True)
+        command = zone._set_enable_command(True)
 
         assert command["command"]["UserAirconSettings.EnabledZones"] == [True, True, False]
 
     def test_set_enable_command_disable(self) -> None:
-        """Test set_enable_command to disable zone."""
+        """Test _set_enable_command to disable zone."""
         zone = ActronAirZone(zone_id=1)
         parent = MagicMock()
         parent.user_aircon_settings.enabled_zones = [True, True, False]
         zone.set_parent_status(parent)
 
-        command = zone.set_enable_command(False)
+        command = zone._set_enable_command(False)
 
         assert command["command"]["UserAirconSettings.EnabledZones"] == [True, False, False]
 
     def test_set_enable_command_out_of_range(self) -> None:
-        """Test set_enable_command with out of range zone_id."""
+        """Test _set_enable_command with out of range zone_id."""
         zone = ActronAirZone(zone_id=5)
         parent = MagicMock()
         parent.user_aircon_settings.enabled_zones = [True, False]
         zone.set_parent_status(parent)
 
         with pytest.raises(ValueError, match="out of range"):
-            zone.set_enable_command(True)
+            zone._set_enable_command(True)
 
 
 class TestPeripheral:

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -178,18 +178,18 @@ class TestZoneAsyncEnable:
 
 
 class TestZoneSetEnableCommand:
-    """Test set_enable_command method edge cases."""
+    """Test _set_enable_command method edge cases."""
 
     def test_set_enable_command_out_of_range(self, zone_with_api: ActronAirZone) -> None:
-        """Test set_enable_command with zone_id out of range."""
+        """Test _set_enable_command with zone_id out of range."""
         # Manually set zone_id to invalid value
         zone_with_api.zone_id = 10  # Out of range (only 3 zones)
 
         with pytest.raises(ValueError, match="Zone index .* out of range"):
-            zone_with_api.set_enable_command(True)
+            zone_with_api._set_enable_command(True)
 
     def test_set_enable_command_without_parent(self) -> None:
-        """Test set_enable_command without parent status."""
+        """Test _set_enable_command without parent status."""
         zone = ActronAirZone(
             zone_id=0,
             zone_number=0,
@@ -199,10 +199,10 @@ class TestZoneSetEnableCommand:
         )
 
         with pytest.raises(RuntimeError, match="Zone must be attached to a parent status"):
-            zone.set_enable_command(True)
+            zone._set_enable_command(True)
 
     def test_set_enable_command_empty_enabled_zones(self) -> None:
-        """Test set_enable_command when enabled_zones is empty (no real data parsed)."""
+        """Test _set_enable_command when enabled_zones is empty (no real data parsed)."""
         status = ActronAirStatus(
             isOnline=True,
             lastKnownState={
@@ -214,10 +214,10 @@ class TestZoneSetEnableCommand:
         zone = status.remote_zone_info[0]
 
         with pytest.raises(ValueError, match="No enabled zones available"):
-            zone.set_enable_command(True)
+            zone._set_enable_command(True)
 
     def test_set_temperature_command_empty_mode(self) -> None:
-        """Test set_temperature_command when mode is empty (no real data parsed)."""
+        """Test _set_temperature_command when mode is empty (no real data parsed)."""
         status = ActronAirStatus(
             isOnline=True,
             lastKnownState={
@@ -229,7 +229,7 @@ class TestZoneSetEnableCommand:
         zone = status.remote_zone_info[0]
 
         with pytest.raises(ValueError, match="No AC mode available"):
-            zone.set_temperature_command(22.0)
+            zone._set_temperature_command(22.0)
 
 
 class TestZoneOptimisticStateNotUpdatedOnError:


### PR DESCRIPTION
## Summary

Standardize command-builder methods as private (`_` prefix) across all three model files, establishing a consistent convention: private `_*_command()` builders + public `async` senders.

Addresses #52 via option 3 (command-builder methods alongside async methods).

## Changes

### `zone.py`
- `set_temperature_command()` → `_set_temperature_command()`
- `set_enable_command()` → `_set_enable_command()`
- Internal callers in `set_temperature()` and `enable()` updated

### `system.py`
- Extracted inline command building from `set_system_mode()` into new `_set_system_mode_command()` private builder
- `set_system_mode()` now delegates to the builder, matching the `settings.py` pattern

### `settings.py`
Already followed this convention — no changes needed.

## Rationale

HA only calls the public async methods (`zone.set_temperature()`, `zone.enable()`, `system.set_system_mode()`, etc.), so the command builders are implementation details. Making them private:
- Clarifies the public API surface
- Makes all three models consistent
- Separates data representation from transport concerns (per #52)

## Checklist

- [x] All 388 tests pass
- [x] 100% code coverage maintained
- [x] All pre-commit checks pass
- [x] No public `set_temperature_command` / `set_enable_command` references remain