### PR TITLE
fix: Track fire-and-forget flush tasks in CommandCoalescer

### DIFF
--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -84,6 +84,7 @@ class CommandCoalescer:
         self._state_manager = state_manager
         self._debounce = debounce_seconds
         self._batches: dict[str, _PendingBatch] = {}
+        self._pending_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def debounce_seconds(self) -> float:
@@ -133,6 +134,8 @@ class CommandCoalescer:
 
         def _schedule_flush(sn: str = serial_number) -> None:
             task = asyncio.ensure_future(self._flush(sn))
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._pending_tasks.discard)
             task.add_done_callback(self._flush_task_done)
 
         batch.timer = loop.call_later(self._debounce, _schedule_flush)
@@ -140,13 +143,22 @@ class CommandCoalescer:
         await future
 
     async def flush_all(self) -> None:
-        """Flush every pending batch immediately, cancelling debounce timers."""
+        """Flush every pending batch immediately, cancelling debounce timers.
+
+        Also awaits any in-flight flush tasks so that all pending work
+        completes before this method returns.
+        """
         serials = list(self._batches.keys())
         for serial in serials:
             batch = self._batches.get(serial)
             if batch and batch.timer:
                 batch.timer.cancel()
             await self._flush(serial)
+
+        # Await any in-flight flush tasks that were scheduled before this call
+        if self._pending_tasks:
+            await asyncio.gather(*self._pending_tasks, return_exceptions=True)
+            self._pending_tasks.clear()
 
     # -- internals --------------------------------------------------------------
 

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -155,10 +155,13 @@ class CommandCoalescer:
                 batch.timer.cancel()
             await self._flush(serial)
 
-        # Await any in-flight flush tasks that were scheduled before this call
+        # Await any in-flight flush tasks that were scheduled before this call.
+        # Snapshot first — done-callbacks mutate the set concurrently.
         if self._pending_tasks:
-            await asyncio.gather(*self._pending_tasks, return_exceptions=True)
-            self._pending_tasks.clear()
+            pending = list(self._pending_tasks)
+            await asyncio.gather(*pending, return_exceptions=True)
+            for task in pending:
+                self._pending_tasks.discard(task)
 
     # -- internals --------------------------------------------------------------
 

--- a/tests/test_coalescer.py
+++ b/tests/test_coalescer.py
@@ -330,13 +330,27 @@ class TestCommandCoalescerTaskTracking:
 
     @pytest.mark.asyncio
     async def test_flush_all_awaits_inflight_tasks(self) -> None:
-        """flush_all awaits in-flight flush tasks before returning."""
-        send_fn = AsyncMock()
-        sm = _state_manager_with_zones("abc", [True, True])
-        coalescer = CommandCoalescer(send_fn, sm, debounce_seconds=0.05)
+        """flush_all awaits a genuinely in-flight background flush task."""
+        gate = asyncio.Event()
 
-        await coalescer.enqueue("abc", _make_zone_command([False, True]))
+        async def _blocking_send(serial: str, cmd: dict[str, Any]) -> None:
+            await gate.wait()
+
+        sm = _state_manager_with_zones("abc", [True, True])
+        coalescer = CommandCoalescer(_blocking_send, sm, debounce_seconds=0.02)
+
+        # Start enqueue — it will block on _blocking_send until gate is set
+        enqueue_task = asyncio.create_task(
+            coalescer.enqueue("abc", _make_zone_command([False, True]))
+        )
+        # Let the debounce timer fire and create the background flush task
+        await asyncio.sleep(0.05)
+        assert len(coalescer._pending_tasks) > 0
+
+        # Release the gate so the flush can finish, then flush_all
+        gate.set()
         await coalescer.flush_all()
+        await enqueue_task
 
         # After flush_all, no pending tasks should remain
         assert len(coalescer._pending_tasks) == 0

--- a/tests/test_coalescer.py
+++ b/tests/test_coalescer.py
@@ -300,6 +300,48 @@ class TestCommandCoalescer:
         assert sent["UserAirconSettings.EnabledZones"] == [False, False, True, True]
 
 
+class TestCommandCoalescerTaskTracking:
+    """Tests for flush task tracking and cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_pending_tasks_set_initialised(self) -> None:
+        """The _pending_tasks set is initialised empty."""
+        send_fn = AsyncMock()
+        sm = StateManager()
+        coalescer = CommandCoalescer(send_fn, sm, debounce_seconds=0.05)
+        assert isinstance(coalescer._pending_tasks, set)
+        assert len(coalescer._pending_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_task_tracked_and_discarded(self) -> None:
+        """Flush tasks are added to _pending_tasks and discarded on completion."""
+        send_fn = AsyncMock()
+        sm = _state_manager_with_zones("abc", [True, True])
+        coalescer = CommandCoalescer(send_fn, sm, debounce_seconds=0.05)
+
+        await coalescer.enqueue("abc", _make_zone_command([False, True]))
+
+        # Allow done-callbacks to execute
+        await asyncio.sleep(0)
+
+        # After the enqueue completes the flush has finished and the
+        # done-callback should have discarded the task from the set.
+        assert len(coalescer._pending_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_all_awaits_inflight_tasks(self) -> None:
+        """flush_all awaits in-flight flush tasks before returning."""
+        send_fn = AsyncMock()
+        sm = _state_manager_with_zones("abc", [True, True])
+        coalescer = CommandCoalescer(send_fn, sm, debounce_seconds=0.05)
+
+        await coalescer.enqueue("abc", _make_zone_command([False, True]))
+        await coalescer.flush_all()
+
+        # After flush_all, no pending tasks should remain
+        assert len(coalescer._pending_tasks) == 0
+
+
 class TestActronAirAPISendCommandCoalescing:
     """Integration tests for command coalescing through ActronAirAPI.send_command."""
 


### PR DESCRIPTION
## Summary

Fixes #53 — Fire-and-forget flush tasks are now tracked in a `_pending_tasks` set on `CommandCoalescer`.

## Changes

- Added `_pending_tasks: set[asyncio.Task[None]]` to `CommandCoalescer.__init__`
- Flush tasks created in `_schedule_flush` are added to the set and auto-discarded via done-callbacks on completion
- `flush_all()` now awaits any in-flight flush tasks (via `asyncio.gather`) before returning, ensuring clean shutdown without unobserved task warnings

## Testing

- Added `TestCommandCoalescerTaskTracking` with 3 tests:
  - `_pending_tasks` initialised empty
  - Flush tasks tracked and discarded after completion
  - `flush_all` awaits in-flight tasks and clears the set
- All 391 tests pass, 100% coverage maintained
- All pre-commit checks pass