### PR TITLE
fix: make verification_uri_complete a required str field

### DIFF
--- a/src/actron_neo_api/models/auth.py
+++ b/src/actron_neo_api/models/auth.py
@@ -11,8 +11,8 @@ class ActronAirDeviceCode(BaseModel):
     device_code: str = Field(..., description="Device verification code")
     user_code: str = Field(..., description="User verification code")
     verification_uri: str = Field(..., description="Verification URI")
-    verification_uri_complete: str | None = Field(
-        None, description="Complete verification URI with user code"
+    verification_uri_complete: str = Field(
+        ..., description="Complete verification URI with user code"
     )
     expires_in: int = Field(..., description="Expiration time in seconds")
     interval: int = Field(..., description="Polling interval in seconds")

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -773,6 +773,7 @@ class TestActronAirAPIOAuth2Methods:
             device_code="test",
             user_code="TEST",
             verification_uri="http://test",
+            verification_uri_complete="http://test?user_code=TEST",
             expires_in=600,
             interval=5,
         )


### PR DESCRIPTION
## Summary

`ActronAirDeviceCode.verification_uri_complete` was typed as `str | None`, but `oauth.py` always synthesizes it before constructing the model — so it's never actually `None` at runtime.

This forced downstream consumers (e.g. the HA integration) to write unnecessary defensive code to satisfy the type checker:

```python
self._verification_uri = (
    device_code_response.verification_uri_complete
    or device_code_response.verification_uri
)
```

## Changes

- **`models/auth.py`**: Changed `verification_uri_complete` from `str | None = None` to `str` (required)
- **`tests/test_actron.py`**: Updated test fixture to supply the now-required field

## Verification

- All 391 tests pass
- 100% coverage maintained
- All pre-commit checks pass