### PR TITLE
feat: add FALLBACK_SUPPORTED_MODES for Que controllers

### DIFF
--- a/src/actron_neo_api/const.py
+++ b/src/actron_neo_api/const.py
@@ -22,7 +22,12 @@ AC_MODE_DRY: Final[str] = "DRY"
 AC_MODE_OFF: Final[str] = "OFF"
 
 # Fallback supported modes for controllers (e.g. Que) that don't report ModeSupport
-FALLBACK_SUPPORTED_MODES: Final[list[str]] = [AC_MODE_COOL, AC_MODE_HEAT, AC_MODE_FAN, AC_MODE_AUTO]
+FALLBACK_SUPPORTED_MODES: Final[tuple[str, ...]] = (
+    AC_MODE_COOL,
+    AC_MODE_HEAT,
+    AC_MODE_FAN,
+    AC_MODE_AUTO,
+)
 
 # HTTP timeout defaults (seconds)
 HTTP_CONNECT_TIMEOUT: Final[float] = 10.0

--- a/src/actron_neo_api/const.py
+++ b/src/actron_neo_api/const.py
@@ -21,6 +21,9 @@ AC_MODE_FAN: Final[str] = "FAN"
 AC_MODE_DRY: Final[str] = "DRY"
 AC_MODE_OFF: Final[str] = "OFF"
 
+# Fallback supported modes for controllers (e.g. Que) that don't report ModeSupport
+FALLBACK_SUPPORTED_MODES: Final[list[str]] = [AC_MODE_COOL, AC_MODE_HEAT, AC_MODE_FAN, AC_MODE_AUTO]
+
 # HTTP timeout defaults (seconds)
 HTTP_CONNECT_TIMEOUT: Final[float] = 10.0
 HTTP_TOTAL_TIMEOUT: Final[float] = 30.0

--- a/src/actron_neo_api/models/settings.py
+++ b/src/actron_neo_api/models/settings.py
@@ -15,6 +15,7 @@ from ..const import (
     AC_MODE_OFF,
     DEFAULT_MAX_SETPOINT,
     DEFAULT_MIN_SETPOINT,
+    FALLBACK_SUPPORTED_MODES,
     TEMP_AUTO_HEAT_MIN,
     TEMP_PHYSICAL_MAX,
     TEMP_PHYSICAL_MIN,
@@ -72,8 +73,8 @@ class ActronAirUserAirconSettings(BaseModel):
     turbo_mode_enabled: bool | dict[str, bool] = Field(
         default_factory=lambda: {"Enabled": False}, alias="TurboMode"
     )
-    mode_support: ActronAirModeSupport = Field(
-        default_factory=lambda: ActronAirModeSupport.model_validate({}),
+    mode_support: ActronAirModeSupport | None = Field(
+        None,
         alias="ModeSupport",
     )
     _parent_status: "ActronAirStatus | None" = None
@@ -94,11 +95,17 @@ class ActronAirUserAirconSettings(BaseModel):
         The returned modes depend on the hardware's ``ModeSupport`` flags.
         Possible values are ``COOL``, ``HEAT``, ``FAN``, ``AUTO``, and ``DRY``.
 
+        When the controller does not report ``ModeSupport`` (e.g. Que
+        controllers), :data:`~actron_neo_api.const.FALLBACK_SUPPORTED_MODES`
+        is returned instead (all modes except DRY).
+
         Returns:
             List of supported mode strings
                 (e.g., ``['COOL', 'HEAT', 'FAN', 'AUTO', 'DRY']``)
 
         """
+        if self.mode_support is None:
+            return list(FALLBACK_SUPPORTED_MODES)
         return [
             mode_const
             for key, mode_const in _MODE_SUPPORT_MAP.items()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -490,13 +490,13 @@ class TestOptimisticStateOff:
 class TestModeSupport:
     """Test ModeSupport parsing and supported_modes property."""
 
-    def test_default_mode_support(self) -> None:
-        """Default mode support includes cool, heat, fan, auto but not dry."""
+    def test_fallback_when_mode_support_missing(self) -> None:
+        """Fallback modes used when ModeSupport is not provided (e.g. Que controllers)."""
+        from actron_neo_api.const import FALLBACK_SUPPORTED_MODES
+
         settings = ActronAirUserAirconSettings.model_validate({})
-        assert "COOL" in settings.supported_modes
-        assert "HEAT" in settings.supported_modes
-        assert "FAN" in settings.supported_modes
-        assert "AUTO" in settings.supported_modes
+        assert settings.mode_support is None
+        assert settings.supported_modes == list(FALLBACK_SUPPORTED_MODES)
         assert "DRY" not in settings.supported_modes
 
     def test_mode_support_from_api_data(self) -> None:


### PR DESCRIPTION
## Summary

Que controllers don't report `ModeSupport` from the API, unlike Neo controllers. Previously, the code relied on Pydantic model defaults which implicitly excluded DRY but wasn't explicit about the intent.

## Changes

- **`const.py`**: Added `FALLBACK_SUPPORTED_MODES` constant — `[COOL, HEAT, FAN, AUTO]` (all modes except DRY)
- **`settings.py`**: Changed `mode_support` field from a defaulted `ActronAirModeSupport` instance to `Optional` (`None` when absent), making it possible to detect when the API didn't provide `ModeSupport` data
- **`settings.py`**: Updated `supported_modes` property to return `FALLBACK_SUPPORTED_MODES` when `mode_support is None` (Que controllers), and derive modes from flags only when explicitly reported (Neo controllers)

## Testing

- All 391 tests pass with 100% coverage
- All pre-commit checks pass