### PR TITLE
chore: migrate build system from setuptools to hatchling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools setuptools-scm wheel
+          pip install build
       - name: Build package
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "actron-neo-api"
@@ -35,10 +35,11 @@ dev = [
 Homepage = "https://github.com/kclif9/actronneoapi"
 Issues = "https://github.com/kclif9/actronneoapi/issues"
 
-[tool.setuptools_scm]
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools.package-data]
-actron_neo_api = ["py.typed"]
+[tool.hatch.build.targets.wheel]
+packages = ["src/actron_neo_api"]
 
 [tool.ruff]
 line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-"""Setup configuration for actron_neo_api package."""
-
-from setuptools import setup
-
-setup(
-    use_scm_version=True,
-    setup_requires=["setuptools_scm"],
-)


### PR DESCRIPTION
## Summary

Migrates the build system from `setuptools` + `setuptools-scm` to `hatchling` + `hatch-vcs` for long-term maintainability.

## Changes

- **pyproject.toml**: Replace `setuptools` build-backend with `hatchling`, replace `setuptools_scm`/`setuptools.package-data` config with `hatch.version` and `hatch.build.targets.wheel`
- **setup.py**: Deleted (no longer needed with hatchling)
- **publish.yml**: Use `python -m build` instead of `python setup.py sdist bdist_wheel`

## Why

- Pure `pyproject.toml` config — no `setup.py` needed
- Faster builds
- First-class PEP 621 support
- Growing ecosystem adoption (pip, black, ruff, uv all use hatchling)
- Git-tag-based versioning preserved via `hatch-vcs` (same underlying `setuptools-scm` library)

## Verification

- ✅ `pip install -e ".[dev]"` succeeds with correct version resolution
- ✅ 395 tests pass, 100% coverage
- ✅ All pre-commit checks pass