### PR TITLE
feat: implement Que SignalR realtime client

### DIFF
--- a/src/actron_neo_api/rt/__init__.py
+++ b/src/actron_neo_api/rt/__init__.py
@@ -15,6 +15,7 @@ from .base import (
     RealtimeTransportType,
 )
 from .mqtt_client import MQTTRTClient, NeoMQTTTopicSet
+from .signalr_client import SignalRRTClient
 
 __all__ = [
     "RealtimeClient",
@@ -27,4 +28,5 @@ __all__ = [
     "RealtimeTransportType",
     "MQTTRTClient",
     "NeoMQTTTopicSet",
+    "SignalRRTClient",
 ]

--- a/src/actron_neo_api/rt/signalr_client.py
+++ b/src/actron_neo_api/rt/signalr_client.py
@@ -1,0 +1,199 @@
+"""Minimal SignalR / SSE realtime client for Que systems.
+
+This module provides a lightweight, asyncio-based SignalR-over-SSE client
+implementation tailored to the needs of the library. It intentionally keeps
+behavior conservative and testable: negotiate/connect is implemented using
+`aiohttp` and incoming SSE "data:" blocks are parsed as JSON and emitted
+as `RealtimeEvent` objects.
+
+The implementation focuses on acceptance-criteria-level behavior described
+in issue #76: connect, subscribe payload send, reconnect + resubscribe,
+and mapping incoming payloads to shared domain models.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import AsyncIterator, Callable, Dict, Optional, Set
+
+import aiohttp
+
+from .base import (
+    RealtimeClient,
+    RealtimeEvent,
+    RealtimeMessage,
+    RealtimeConnectionDetails,
+    RealtimeTransportType,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SignalRRTClient(RealtimeClient):
+    """SignalR-over-SSE realtime client (minimal, asyncio/aiohttp based).
+
+    Notes:
+    - `connection_details.endpoint` should be the full URL to the SignalR
+      endpoint that speaks Server-Sent Events (text/event-stream).
+    - Subscribes are performed by POSTing a simple JSON payload to the
+      provided endpoint + "/subscribe". The Android client uses a similar
+      command pattern; this keeps the client generic and testable.
+    """
+
+    transport_type = RealtimeTransportType.SIGNALR
+
+    def __init__(
+        self,
+        connection_details: RealtimeConnectionDetails,
+        access_token: str,
+        *,
+        session: Optional[aiohttp.ClientSession] = None,
+        reconnect_initial_delay: float = 1.0,
+        reconnect_max_delay: float = 30.0,
+    ) -> None:
+        self._connection_details = connection_details
+        self._access_token = access_token
+        self._session = session
+        self._reconnect_initial_delay = reconnect_initial_delay
+        self._reconnect_max_delay = reconnect_max_delay
+
+        self._subscriptions: Set[str] = set()
+        self._callbacks: list[Callable[[RealtimeEvent], None]] = []
+        self._events: "asyncio.Queue[RealtimeEvent]" = asyncio.Queue()
+
+        self._supervisor_task: Optional[asyncio.Task] = None
+        self._running = False
+
+    def register_callback(self, callback: Callable[[RealtimeEvent], None]) -> None:
+        self._callbacks.append(callback)
+
+    async def connect(self) -> None:
+        if self._supervisor_task is not None:
+            return
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+        self._running = True
+        self._supervisor_task = asyncio.create_task(self._run_supervisor())
+
+    async def disconnect(self) -> None:
+        self._running = False
+        task = self._supervisor_task
+        self._supervisor_task = None
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def subscribe(self, device_serial: str) -> None:
+        self._subscriptions.add(device_serial)
+        await self._send_subscribe(device_serial)
+
+    async def unsubscribe(self, device_serial: str) -> None:
+        self._subscriptions.discard(device_serial)
+        await self._send_unsubscribe(device_serial)
+
+    async def update_access_token(self, access_token: str) -> None:
+        self._access_token = access_token
+
+    async def iter_events(self) -> AsyncIterator[RealtimeEvent]:
+        while True:
+            ev = await self._events.get()
+            yield ev
+
+    async def _send_subscribe(self, device_serial: str) -> None:
+        if not self._session:
+            return
+        url = f"{self._connection_details.endpoint.rstrip('/')}/subscribe"
+        headers = {"Authorization": f"Bearer {self._access_token}"}
+        try:
+            async with self._session.post(url, json={"serial": device_serial}, headers=headers, timeout=10):
+                pass
+        except Exception:  # pragma: no cover - network defensive behavior
+            _LOGGER.debug("subscribe POST failed", exc_info=True)
+
+    async def _send_unsubscribe(self, device_serial: str) -> None:
+        if not self._session:
+            return
+        url = f"{self._connection_details.endpoint.rstrip('/')}/unsubscribe"
+        headers = {"Authorization": f"Bearer {self._access_token}"}
+        try:
+            async with self._session.post(url, json={"serial": device_serial}, headers=headers, timeout=10):
+                pass
+        except Exception:  # pragma: no cover - network defensive behavior
+            _LOGGER.debug("unsubscribe POST failed", exc_info=True)
+
+    async def _run_supervisor(self) -> None:
+        backoff = self._reconnect_initial_delay
+        while self._running:
+            try:
+                await self._connect_and_listen()
+                backoff = self._reconnect_initial_delay
+            except asyncio.CancelledError:
+                break
+            except Exception:  # pragma: no cover - reconnect/backoff loop
+                _LOGGER.exception("SignalR supervisor error; reconnecting in %s", backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(self._reconnect_max_delay, backoff * 2)
+
+    async def _connect_and_listen(self) -> None:
+        if not self._session:
+            raise RuntimeError("no aiohttp session available")
+        headers = {"Authorization": f"Bearer {self._access_token}", "Accept": "text/event-stream"}
+        url = self._connection_details.endpoint
+        async with self._session.get(url, headers=headers) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"sse connect failed: {resp.status}")
+            # SSE: read stream and accumulate data: lines
+            buffer = ""
+            async for raw in resp.content:  # type: ignore[attr-defined]
+                if not self._running:
+                    break
+                try:
+                    line = raw.decode()
+                except Exception:
+                    continue
+                if line.startswith("data:"):
+                    buffer += line[len("data:"):].strip()
+                elif line.strip() == "":
+                    if buffer:
+                        try:
+                            payload = json.loads(buffer)
+                        except Exception:
+                            _LOGGER.debug("invalid sse json: %s", buffer)
+                        else:
+                            self._handle_payload(payload)
+                        finally:
+                            buffer = ""
+
+    def _handle_payload(self, payload: Dict) -> None:
+        try:
+            # Prefer domain model conversion when payload contains known fields
+            if isinstance(payload, dict) and ("Status" in payload or "status" in payload):
+                try:
+                    from actron_neo_api.models.status import ActronAirStatus
+
+                    status_payload = payload.get("Status") or payload.get("status")
+                    domain = ActronAirStatus.model_validate(status_payload)
+                except Exception:
+                    domain = payload
+            else:
+                domain = payload
+
+            ev = RealtimeEvent(message=RealtimeMessage(domain_model=domain))
+            asyncio.create_task(self._emit_event(ev))
+        except Exception:
+            _LOGGER.exception("failed to handle incoming signalr payload")
+
+    async def _emit_event(self, ev: RealtimeEvent) -> None:
+        for cb in list(self._callbacks):
+            try:
+                cb(ev)
+            except Exception:
+                _LOGGER.exception("event callback failed")
+        await self._events.put(ev)

--- a/src/actron_neo_api/rt/signalr_client.py
+++ b/src/actron_neo_api/rt/signalr_client.py
@@ -145,10 +145,19 @@ class SignalRRTClient(RealtimeClient):
         if not self._session:
             raise RuntimeError("no aiohttp session available")
         headers = {"Authorization": f"Bearer {self._access_token}", "Accept": "text/event-stream"}
-        url = self._connection_details.endpoint
+        # Perform SignalR negotiate to obtain the best SSE URL
+        try:
+            sse_url = await self._negotiate()
+        except Exception:
+            _LOGGER.debug("negotiate failed; falling back to endpoint", exc_info=True)
+            sse_url = self._connection_details.endpoint
+
+        url = sse_url
         async with self._session.get(url, headers=headers) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"sse connect failed: {resp.status}")
+            # restore subscriptions immediately after a successful connection
+            await self._restore_subscriptions()
             # SSE: read stream and accumulate data: lines
             buffer = ""
             async for raw in resp.content:  # type: ignore[attr-defined]
@@ -170,6 +179,43 @@ class SignalRRTClient(RealtimeClient):
                             self._handle_payload(payload)
                         finally:
                             buffer = ""
+
+    async def _negotiate(self) -> str:
+        """Call the SignalR negotiate endpoint and return an SSE connect URL.
+
+        The negotiate response varies; prefer an explicit `url` when present,
+        otherwise build a serverSentEvents URL using a connectionId/token.
+        """
+        url = f"{self._connection_details.endpoint.rstrip('/')}/negotiate"
+        headers = {"Authorization": f"Bearer {self._access_token}"}
+        async with self._session.post(url, headers=headers, timeout=10) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"negotiate failed: {resp.status}")
+            data = await resp.json()
+
+        # If server returned a connect URL, use it directly.
+        if isinstance(data, dict) and "url" in data:
+            return data["url"]
+
+        # Otherwise try to construct a serverSentEvents URL.
+        connection_id = data.get("connectionId") if isinstance(data, dict) else None
+        token = data.get("connectionToken") if isinstance(data, dict) else None
+        base = self._connection_details.endpoint.rstrip('/')
+        if connection_id:
+            # SignalR-compatible query for serverSentEvents transport
+            return f"{base}/?id={connection_id}&transport=serverSentEvents"
+        if token:
+            return f"{base}/?transport=serverSentEvents&connectionToken={token}"
+        # Fallback to the base endpoint
+        return self._connection_details.endpoint
+
+    async def _restore_subscriptions(self) -> None:
+        """Resend subscribe commands for current subscriptions after reconnect."""
+        for serial in list(self._subscriptions):
+            try:
+                await self._send_subscribe(serial)
+            except Exception:
+                _LOGGER.debug("failed to resubscribe %s", serial, exc_info=True)
 
     def _handle_payload(self, payload: Dict) -> None:
         try:

--- a/src/actron_neo_api/rt/signalr_client.py
+++ b/src/actron_neo_api/rt/signalr_client.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import AsyncIterator, Callable, Optional
+from typing import Any, AsyncIterator, Callable, Optional
 
 import aiohttp
 
 from .base import (
     RealtimeClient,
     RealtimeConnectionDetails,
+    RealtimeConnectionEvent,
+    RealtimeConnectionState,
     RealtimeEvent,
     RealtimeEventKind,
     RealtimeMessage,
@@ -30,6 +32,7 @@ from .base import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_SIGNALR_SUBSCRIBE_REFRESH_SECONDS = 300.0
 
 
 class SignalRRTClient(RealtimeClient):
@@ -62,10 +65,21 @@ class SignalRRTClient(RealtimeClient):
             session: Optional aiohttp session (for testing/mocking).
             reconnect_initial_delay: Initial reconnect backoff (seconds).
             reconnect_max_delay: Max reconnect backoff (seconds).
+
+        Raises:
+            ValueError: If arguments are invalid.
         """
+        if not access_token.strip():
+            raise ValueError("access_token cannot be empty")
+        if reconnect_initial_delay <= 0:
+            raise ValueError("reconnect_initial_delay must be greater than zero")
+        if reconnect_max_delay < reconnect_initial_delay:
+            raise ValueError("reconnect_max_delay must be greater than or equal to initial delay")
+
         self._connection_details = connection_details
         self._access_token = access_token
         self._session = session
+        self._external_session = session is not None
         self._reconnect_initial_delay = reconnect_initial_delay
         self._reconnect_max_delay = reconnect_max_delay
 
@@ -74,6 +88,8 @@ class SignalRRTClient(RealtimeClient):
         self._events: asyncio.Queue[RealtimeEvent] = asyncio.Queue()
 
         self._supervisor_task: Optional[asyncio.Task[None]] = None
+        self._resubscribe_task: Optional[asyncio.Task[None]] = None
+        self._connection_state = RealtimeConnectionState.DISCONNECTED
         self._running = False
 
     def register_callback(self, callback: Callable[[RealtimeEvent], None]) -> None:
@@ -82,16 +98,25 @@ class SignalRRTClient(RealtimeClient):
 
     async def connect(self) -> None:
         """Connect to the SignalR endpoint and start listening."""
-        if self._supervisor_task is not None:
+        if self._supervisor_task is not None and not self._supervisor_task.done():
             return
-        if self._session is None:
+        self._supervisor_task = None
+        if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
+            self._external_session = False
         self._running = True
         self._supervisor_task = asyncio.create_task(self._run_supervisor())
 
     async def disconnect(self) -> None:
         """Disconnect from the SignalR endpoint and stop listening."""
         self._running = False
+        if self._resubscribe_task is not None:
+            self._resubscribe_task.cancel()
+            try:
+                await self._resubscribe_task
+            except asyncio.CancelledError:
+                pass
+            self._resubscribe_task = None
         task = self._supervisor_task
         self._supervisor_task = None
         if task:
@@ -100,29 +125,50 @@ class SignalRRTClient(RealtimeClient):
                 await task
             except asyncio.CancelledError:
                 pass
-        if self._session is not None:
+        if self._session is not None and not self._session.closed and not self._external_session:
             await self._session.close()
             self._session = None
+        await self._set_state(RealtimeConnectionState.DISCONNECTED)
 
     async def subscribe(self, device_serial: str) -> None:
         """Subscribe to updates for a device serial."""
-        self._subscriptions.add(device_serial)
-        await self._send_subscribe(device_serial)
+        serial = device_serial.strip()
+        if not serial:
+            raise ValueError("device_serial cannot be empty")
+        self._subscriptions.add(serial)
+        await self._send_subscribe(serial)
 
     async def unsubscribe(self, device_serial: str) -> None:
         """Unsubscribe from updates for a device serial."""
-        self._subscriptions.discard(device_serial)
-        await self._send_unsubscribe(device_serial)
+        serial = device_serial.strip()
+        if not serial:
+            raise ValueError("device_serial cannot be empty")
+        self._subscriptions.discard(serial)
+        await self._send_unsubscribe(serial)
 
     async def update_access_token(self, access_token: str) -> None:
-        """Update the OAuth2 access token used for authentication."""
-        self._access_token = access_token
+        """Update the OAuth2 access token used for authentication.
+
+        Args:
+            access_token: OAuth2 access token.
+
+        Raises:
+            ValueError: If the token is empty.
+        """
+        normalized_access_token = access_token.strip()
+        if not normalized_access_token:
+            raise ValueError("access_token cannot be empty")
+        self._access_token = normalized_access_token
 
     async def iter_events(self) -> AsyncIterator[RealtimeEvent]:
         """Yield realtime events as they arrive."""
-        while True:
+        while self._running or not self._events.empty():
             ev = await self._events.get()
             yield ev
+
+    async def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        """Publish is not supported for SignalR transport."""
+        raise NotImplementedError("SignalR transport does not support publish")
 
     async def _send_subscribe(self, device_serial: str) -> None:
         if not self._session:
@@ -137,19 +183,6 @@ class SignalRRTClient(RealtimeClient):
                 pass
         except Exception:  # pragma: no cover - network defensive behavior
             _LOGGER.debug("subscribe POST failed", exc_info=True)
-            session = self._session
-            if session is None:
-                return
-            url = f"{self._connection_details.endpoint.rstrip('/')}/subscribe"
-            headers = {"Authorization": f"Bearer {self._access_token}"}
-            try:
-                timeout = aiohttp.ClientTimeout(total=10)
-                async with session.post(
-                    url, json={"serial": device_serial}, headers=headers, timeout=timeout
-                ):
-                    pass
-            except Exception:  # pragma: no cover - network defensive behavior
-                _LOGGER.debug("subscribe POST failed", exc_info=True)
 
     async def _send_unsubscribe(self, device_serial: str) -> None:
         if not self._session:
@@ -164,32 +197,32 @@ class SignalRRTClient(RealtimeClient):
                 pass
         except Exception:  # pragma: no cover - network defensive behavior
             _LOGGER.debug("unsubscribe POST failed", exc_info=True)
-            session = self._session
-            if session is None:
-                return
-            url = f"{self._connection_details.endpoint.rstrip('/')}/unsubscribe"
-            headers = {"Authorization": f"Bearer {self._access_token}"}
-            try:
-                timeout = aiohttp.ClientTimeout(total=10)
-                async with session.post(
-                    url, json={"serial": device_serial}, headers=headers, timeout=timeout
-                ):
-                    pass
-            except Exception:  # pragma: no cover - network defensive behavior
-                _LOGGER.debug("unsubscribe POST failed", exc_info=True)
 
     async def _run_supervisor(self) -> None:
         backoff = self._reconnect_initial_delay
         while self._running:
             try:
+                await self._set_state(RealtimeConnectionState.CONNECTING)
                 await self._connect_and_listen()
-                backoff = self._reconnect_initial_delay
+                if self._running:
+                    await self._set_state(
+                        RealtimeConnectionState.RECONNECTING,
+                        reason="event stream ended",
+                    )
+                    await asyncio.sleep(backoff)
+                    backoff = min(self._reconnect_max_delay, backoff * 2)
+                else:
+                    backoff = self._reconnect_initial_delay
             except asyncio.CancelledError:
                 break
             except Exception:  # pragma: no cover - reconnect/backoff loop
                 _LOGGER.exception("SignalR supervisor error; reconnecting in %s", backoff)
+                await self._set_state(
+                    RealtimeConnectionState.RECONNECTING, reason="transport error"
+                )
                 await asyncio.sleep(backoff)
                 backoff = min(self._reconnect_max_delay, backoff * 2)
+        await self._set_state(RealtimeConnectionState.DISCONNECTED)
 
     async def _connect_and_listen(self) -> None:
         if not self._session:
@@ -208,27 +241,38 @@ class SignalRRTClient(RealtimeClient):
                 raise RuntimeError(f"sse connect failed: {resp.status}")
             # restore subscriptions immediately after a successful connection
             await self._restore_subscriptions()
+            await self._set_state(RealtimeConnectionState.CONNECTED)
+            self._resubscribe_task = asyncio.create_task(self._run_subscription_refresh())
             # SSE: read stream and accumulate data: lines
             buffer = ""
-            async for raw in resp.content:
-                if not self._running:
-                    break
-                try:
-                    line = raw.decode()
-                except Exception:
-                    continue
-                if line.startswith("data:"):
-                    buffer += line[len("data:") :].strip()
-                elif line.strip() == "":
-                    if buffer:
-                        try:
-                            payload = json.loads(buffer)
-                        except Exception:
-                            _LOGGER.debug("invalid sse json: %s", buffer)
-                        else:
-                            self._handle_payload(payload)
-                        finally:
-                            buffer = ""
+            try:
+                async for raw in resp.content:
+                    if not self._running:
+                        break
+                    try:
+                        line = raw.decode()
+                    except Exception:
+                        continue
+                    if line.startswith("data:"):
+                        buffer += line[len("data:") :].strip()
+                    elif line.strip() == "":
+                        if buffer:
+                            try:
+                                payload = json.loads(buffer)
+                            except Exception:
+                                _LOGGER.debug("invalid sse json: %s", buffer)
+                            else:
+                                self._handle_payload(payload)
+                            finally:
+                                buffer = ""
+            finally:
+                if self._resubscribe_task is not None:
+                    self._resubscribe_task.cancel()
+                    try:
+                        await self._resubscribe_task
+                    except asyncio.CancelledError:
+                        pass
+                    self._resubscribe_task = None
 
     async def _negotiate(self) -> str:
         """Call the SignalR negotiate endpoint and return an SSE connect URL.
@@ -271,6 +315,14 @@ class SignalRRTClient(RealtimeClient):
             except Exception:
                 _LOGGER.debug("failed to resubscribe %s", serial, exc_info=True)
 
+    async def _run_subscription_refresh(self) -> None:
+        """Periodically refresh subscriptions while connected."""
+        while self._running:
+            await asyncio.sleep(_SIGNALR_SUBSCRIBE_REFRESH_SECONDS)
+            if not self._running:
+                break
+            await self._restore_subscriptions()
+
     def _handle_payload(self, payload: dict[str, object]) -> None:
         """Parse and emit a domain event from a raw payload."""
         try:
@@ -307,3 +359,21 @@ class SignalRRTClient(RealtimeClient):
             except Exception:
                 _LOGGER.exception("event callback failed")
         await self._events.put(ev)
+
+    async def _set_state(
+        self,
+        state: RealtimeConnectionState,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Update connection state and emit a connection event."""
+        previous_state = self._connection_state
+        self._connection_state = state
+        event = RealtimeConnectionEvent(
+            transport=self.transport_type,
+            kind=RealtimeEventKind.CONNECTION,
+            state=state,
+            previous_state=previous_state,
+            reason=reason,
+        )
+        await self._events.put(event)

--- a/src/actron_neo_api/rt/signalr_client.py
+++ b/src/actron_neo_api/rt/signalr_client.py
@@ -10,20 +10,22 @@ The implementation focuses on acceptance-criteria-level behavior described
 in issue #76: connect, subscribe payload send, reconnect + resubscribe,
 and mapping incoming payloads to shared domain models.
 """
+
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
-from typing import AsyncIterator, Callable, Dict, Optional, Set
+from typing import AsyncIterator, Callable, Optional
 
 import aiohttp
 
 from .base import (
     RealtimeClient,
-    RealtimeEvent,
-    RealtimeMessage,
     RealtimeConnectionDetails,
+    RealtimeEvent,
+    RealtimeEventKind,
+    RealtimeMessage,
     RealtimeTransportType,
 )
 
@@ -52,23 +54,34 @@ class SignalRRTClient(RealtimeClient):
         reconnect_initial_delay: float = 1.0,
         reconnect_max_delay: float = 30.0,
     ) -> None:
+        """Initialize the SignalRRTClient.
+
+        Args:
+            connection_details: Connection info for the SignalR endpoint.
+            access_token: OAuth2 access token.
+            session: Optional aiohttp session (for testing/mocking).
+            reconnect_initial_delay: Initial reconnect backoff (seconds).
+            reconnect_max_delay: Max reconnect backoff (seconds).
+        """
         self._connection_details = connection_details
         self._access_token = access_token
         self._session = session
         self._reconnect_initial_delay = reconnect_initial_delay
         self._reconnect_max_delay = reconnect_max_delay
 
-        self._subscriptions: Set[str] = set()
+        self._subscriptions: set[str] = set()
         self._callbacks: list[Callable[[RealtimeEvent], None]] = []
-        self._events: "asyncio.Queue[RealtimeEvent]" = asyncio.Queue()
+        self._events: asyncio.Queue[RealtimeEvent] = asyncio.Queue()
 
-        self._supervisor_task: Optional[asyncio.Task] = None
+        self._supervisor_task: Optional[asyncio.Task[None]] = None
         self._running = False
 
     def register_callback(self, callback: Callable[[RealtimeEvent], None]) -> None:
+        """Register a callback to receive realtime events."""
         self._callbacks.append(callback)
 
     async def connect(self) -> None:
+        """Connect to the SignalR endpoint and start listening."""
         if self._supervisor_task is not None:
             return
         if self._session is None:
@@ -77,6 +90,7 @@ class SignalRRTClient(RealtimeClient):
         self._supervisor_task = asyncio.create_task(self._run_supervisor())
 
     async def disconnect(self) -> None:
+        """Disconnect from the SignalR endpoint and stop listening."""
         self._running = False
         task = self._supervisor_task
         self._supervisor_task = None
@@ -91,17 +105,21 @@ class SignalRRTClient(RealtimeClient):
             self._session = None
 
     async def subscribe(self, device_serial: str) -> None:
+        """Subscribe to updates for a device serial."""
         self._subscriptions.add(device_serial)
         await self._send_subscribe(device_serial)
 
     async def unsubscribe(self, device_serial: str) -> None:
+        """Unsubscribe from updates for a device serial."""
         self._subscriptions.discard(device_serial)
         await self._send_unsubscribe(device_serial)
 
     async def update_access_token(self, access_token: str) -> None:
+        """Update the OAuth2 access token used for authentication."""
         self._access_token = access_token
 
     async def iter_events(self) -> AsyncIterator[RealtimeEvent]:
+        """Yield realtime events as they arrive."""
         while True:
             ev = await self._events.get()
             yield ev
@@ -112,10 +130,26 @@ class SignalRRTClient(RealtimeClient):
         url = f"{self._connection_details.endpoint.rstrip('/')}/subscribe"
         headers = {"Authorization": f"Bearer {self._access_token}"}
         try:
-            async with self._session.post(url, json={"serial": device_serial}, headers=headers, timeout=10):
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with self._session.post(
+                url, json={"serial": device_serial}, headers=headers, timeout=timeout
+            ):
                 pass
         except Exception:  # pragma: no cover - network defensive behavior
             _LOGGER.debug("subscribe POST failed", exc_info=True)
+            session = self._session
+            if session is None:
+                return
+            url = f"{self._connection_details.endpoint.rstrip('/')}/subscribe"
+            headers = {"Authorization": f"Bearer {self._access_token}"}
+            try:
+                timeout = aiohttp.ClientTimeout(total=10)
+                async with session.post(
+                    url, json={"serial": device_serial}, headers=headers, timeout=timeout
+                ):
+                    pass
+            except Exception:  # pragma: no cover - network defensive behavior
+                _LOGGER.debug("subscribe POST failed", exc_info=True)
 
     async def _send_unsubscribe(self, device_serial: str) -> None:
         if not self._session:
@@ -123,10 +157,26 @@ class SignalRRTClient(RealtimeClient):
         url = f"{self._connection_details.endpoint.rstrip('/')}/unsubscribe"
         headers = {"Authorization": f"Bearer {self._access_token}"}
         try:
-            async with self._session.post(url, json={"serial": device_serial}, headers=headers, timeout=10):
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with self._session.post(
+                url, json={"serial": device_serial}, headers=headers, timeout=timeout
+            ):
                 pass
         except Exception:  # pragma: no cover - network defensive behavior
             _LOGGER.debug("unsubscribe POST failed", exc_info=True)
+            session = self._session
+            if session is None:
+                return
+            url = f"{self._connection_details.endpoint.rstrip('/')}/unsubscribe"
+            headers = {"Authorization": f"Bearer {self._access_token}"}
+            try:
+                timeout = aiohttp.ClientTimeout(total=10)
+                async with session.post(
+                    url, json={"serial": device_serial}, headers=headers, timeout=timeout
+                ):
+                    pass
+            except Exception:  # pragma: no cover - network defensive behavior
+                _LOGGER.debug("unsubscribe POST failed", exc_info=True)
 
     async def _run_supervisor(self) -> None:
         backoff = self._reconnect_initial_delay
@@ -160,7 +210,7 @@ class SignalRRTClient(RealtimeClient):
             await self._restore_subscriptions()
             # SSE: read stream and accumulate data: lines
             buffer = ""
-            async for raw in resp.content:  # type: ignore[attr-defined]
+            async for raw in resp.content:
                 if not self._running:
                     break
                 try:
@@ -168,7 +218,7 @@ class SignalRRTClient(RealtimeClient):
                 except Exception:
                     continue
                 if line.startswith("data:"):
-                    buffer += line[len("data:"):].strip()
+                    buffer += line[len("data:") :].strip()
                 elif line.strip() == "":
                     if buffer:
                         try:
@@ -186,28 +236,32 @@ class SignalRRTClient(RealtimeClient):
         The negotiate response varies; prefer an explicit `url` when present,
         otherwise build a serverSentEvents URL using a connectionId/token.
         """
+        session = self._session
+        if session is None:
+            raise RuntimeError("no aiohttp session available")
         url = f"{self._connection_details.endpoint.rstrip('/')}/negotiate"
         headers = {"Authorization": f"Bearer {self._access_token}"}
-        async with self._session.post(url, headers=headers, timeout=10) as resp:
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with session.post(url, headers=headers, timeout=timeout) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"negotiate failed: {resp.status}")
             data = await resp.json()
 
         # If server returned a connect URL, use it directly.
         if isinstance(data, dict) and "url" in data:
-            return data["url"]
+            return str(data["url"])
 
         # Otherwise try to construct a serverSentEvents URL.
         connection_id = data.get("connectionId") if isinstance(data, dict) else None
         token = data.get("connectionToken") if isinstance(data, dict) else None
-        base = self._connection_details.endpoint.rstrip('/')
+        base = self._connection_details.endpoint.rstrip("/")
         if connection_id:
             # SignalR-compatible query for serverSentEvents transport
             return f"{base}/?id={connection_id}&transport=serverSentEvents"
         if token:
             return f"{base}/?transport=serverSentEvents&connectionToken={token}"
         # Fallback to the base endpoint
-        return self._connection_details.endpoint
+        return str(self._connection_details.endpoint)
 
     async def _restore_subscriptions(self) -> None:
         """Resend subscribe commands for current subscriptions after reconnect."""
@@ -217,9 +271,12 @@ class SignalRRTClient(RealtimeClient):
             except Exception:
                 _LOGGER.debug("failed to resubscribe %s", serial, exc_info=True)
 
-    def _handle_payload(self, payload: Dict) -> None:
+    def _handle_payload(self, payload: dict[str, object]) -> None:
+        """Parse and emit a domain event from a raw payload."""
         try:
             # Prefer domain model conversion when payload contains known fields
+            domain: object | None = None
+            topic = "signalr"
             if isinstance(payload, dict) and ("Status" in payload or "status" in payload):
                 try:
                     from actron_neo_api.models.status import ActronAirStatus
@@ -231,8 +288,15 @@ class SignalRRTClient(RealtimeClient):
             else:
                 domain = payload
 
-            ev = RealtimeEvent(message=RealtimeMessage(domain_model=domain))
-            asyncio.create_task(self._emit_event(ev))
+            msg = RealtimeMessage(
+                transport=RealtimeTransportType.SIGNALR,
+                kind=RealtimeEventKind.MESSAGE,
+                topic=topic,
+                payload=payload,
+                raw_payload=None,
+                domain_model=domain,
+            )
+            asyncio.create_task(self._emit_event(msg))
         except Exception:
             _LOGGER.exception("failed to handle incoming signalr payload")
 

--- a/tests/test_realtime_package.py
+++ b/tests/test_realtime_package.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from actron_neo_api.rt import (
     MQTTRTClient,
+    SignalRRTClient,
     RealtimeClient,
     RealtimeConnectionDetails,
     RealtimeConnectionEvent,
@@ -25,3 +26,4 @@ def test_realtime_package_exports() -> None:
     assert RealtimeClient.__name__ == "RealtimeClient"
     assert RealtimeConnectionDetails.__name__ == "RealtimeConnectionDetails"
     assert MQTTRTClient.__name__ == "MQTTRTClient"
+    assert SignalRRTClient.__name__ == "SignalRRTClient"

--- a/tests/test_realtime_package.py
+++ b/tests/test_realtime_package.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from actron_neo_api.rt import (
     MQTTRTClient,
-    SignalRRTClient,
     RealtimeClient,
     RealtimeConnectionDetails,
     RealtimeConnectionEvent,
@@ -12,6 +11,7 @@ from actron_neo_api.rt import (
     RealtimeEventKind,
     RealtimeMessage,
     RealtimeTransportType,
+    SignalRRTClient,
 )
 
 

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -1,0 +1,47 @@
+"""Unit tests for the SignalR realtime client skeleton."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from actron_neo_api.rt import RealtimeConnectionDetails, SignalRRTClient
+
+
+def test_register_callback_and_emit(tmp_path) -> None:
+    details = RealtimeConnectionDetails(endpoint="https://example.test/signalr", port=443, protocol="https", user_id="u")
+    client = SignalRRTClient(details, access_token="secret")
+
+    seen: list = []
+
+    def cb(ev):
+        seen.append(ev)
+
+    client.register_callback(cb)
+
+    ev = type("E", (), {"message": type("M", (), {"domain_model": {"foo": "bar"}})})()
+
+    # schedule emit and consume from queue
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(client._emit_event(ev))
+
+    # callback should have been called and queue populated
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_iter_events_and_update_token() -> None:
+    details = RealtimeConnectionDetails(endpoint="https://example.test/signalr", port=443, protocol="https", user_id="u")
+    client = SignalRRTClient(details, access_token="oldtoken")
+
+    # put a fake event onto the queue
+    ev = type("E", (), {"message": type("M", (), {"domain_model": {"k": "v"}})})()
+    await client._emit_event(ev)
+
+    # update token should not raise
+    await client.update_access_token("newtoken")
+
+    it = client.iter_events()
+    got = await asyncio.wait_for(it.__anext__(), timeout=1.0)
+    assert got is ev

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -1,76 +1,594 @@
-"""Unit tests for the SignalR realtime client skeleton."""
+"""Unit tests for the SignalR realtime client."""
 
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
+import aiohttp
 import pytest
 
 from actron_neo_api.rt import RealtimeConnectionDetails, SignalRRTClient
+from actron_neo_api.rt.base import (
+    RealtimeEvent,
+    RealtimeEventKind,
+    RealtimeMessage,
+    RealtimeTransportType,
+)
 
 
-import pytest
+class _BadRaw:
+    """Bytes-like object that fails decode for SSE parsing tests."""
 
-@pytest.mark.asyncio
-async def test_register_callback_and_emit(tmp_path) -> None:
-    details = RealtimeConnectionDetails(
+    def decode(self) -> str:
+        raise UnicodeDecodeError("utf-8", b"x", 0, 1, "bad")
+
+
+class _AsyncContent:
+    """Async iterator used as aiohttp response content."""
+
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+        self._idx = 0
+
+    def __aiter__(self) -> _AsyncContent:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._idx >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._idx]
+        self._idx += 1
+        return item
+
+
+class _Response:
+    """Minimal async-context HTTP response fake."""
+
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        json_data: Any = None,
+        content_items: list[Any] | None = None,
+    ) -> None:
+        self.status = status
+        self._json_data = json_data
+        self.content = _AsyncContent(content_items or [])
+
+    async def __aenter__(self) -> _Response:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        return False
+
+    async def json(self) -> Any:
+        return self._json_data
+
+
+class _Session:
+    """Minimal aiohttp ClientSession fake."""
+
+    def __init__(
+        self,
+        *,
+        post_responses: list[_Response] | None = None,
+        get_responses: list[_Response] | None = None,
+    ) -> None:
+        self.post_responses = post_responses or []
+        self.get_responses = get_responses or []
+        self.post_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    def post(self, url: str, **kwargs: Any) -> _Response:
+        self.post_calls.append({"url": url, **kwargs})
+        if self.post_responses:
+            return self.post_responses.pop(0)
+        return _Response(status=200, json_data={})
+
+    def get(self, url: str, **kwargs: Any) -> _Response:
+        self.get_calls.append({"url": url, **kwargs})
+        if self.get_responses:
+            return self.get_responses.pop(0)
+        return _Response(status=200, content_items=[])
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _details() -> RealtimeConnectionDetails:
+    return RealtimeConnectionDetails(
         endpoint="https://example.test/signalr",
         port=443,
         protocol="https",
         user_id="u",
     )
-    client = SignalRRTClient(details, access_token="secret")
 
-    seen: list = []
 
-    def cb(ev):
-        seen.append(ev)
-
-    client.register_callback(cb)
-
-    from actron_neo_api.rt.base import RealtimeEventKind, RealtimeMessage, RealtimeTransportType
-
-    msg = RealtimeMessage(
+def _message(payload: dict[str, Any] | None = None) -> RealtimeMessage:
+    body = payload or {"foo": "bar"}
+    return RealtimeMessage(
         transport=RealtimeTransportType.SIGNALR,
         kind=RealtimeEventKind.MESSAGE,
         topic="signalr",
-        payload={"foo": "bar"},
+        payload=body,
         raw_payload=None,
-        domain_model={"foo": "bar"},
+        domain_model=body,
     )
 
-    # schedule emit and consume from queue
+
+@pytest.mark.asyncio
+async def test_register_callback_and_emit() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    seen: list[RealtimeEvent] = []
+
+    def cb(ev: RealtimeEvent) -> None:
+        seen.append(ev)
+
+    client.register_callback(cb)
+    msg = _message()
+
     await client._emit_event(msg)
 
-    # callback should have been called and queue populated
     assert len(seen) == 1
+    assert seen[0] == msg
+
+
+@pytest.mark.asyncio
+async def test_emit_event_handles_callback_exception() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    seen: list[RealtimeEvent] = []
+
+    def bad(_: RealtimeEvent) -> None:
+        raise ValueError("boom")
+
+    def good(ev: RealtimeEvent) -> None:
+        seen.append(ev)
+
+    client.register_callback(bad)
+    client.register_callback(good)
+    msg = _message()
+
+    await client._emit_event(msg)
+
+    assert seen == [msg]
 
 
 @pytest.mark.asyncio
 async def test_iter_events_and_update_token() -> None:
-    details = RealtimeConnectionDetails(
-        endpoint="https://example.test/signalr",
-        port=443,
-        protocol="https",
-        user_id="u",
-    )
-    client = SignalRRTClient(details, access_token="oldtoken")
+    client = SignalRRTClient(_details(), access_token="oldtoken")
+    msg = _message({"k": "v"})
 
-    from actron_neo_api.rt.base import RealtimeEventKind, RealtimeMessage, RealtimeTransportType
-
-    msg = RealtimeMessage(
-        transport=RealtimeTransportType.SIGNALR,
-        kind=RealtimeEventKind.MESSAGE,
-        topic="signalr",
-        payload={"k": "v"},
-        raw_payload=None,
-        domain_model={"k": "v"},
-    )
     await client._emit_event(msg)
-
-    # update token should not raise
     await client.update_access_token("newtoken")
 
-    it = client.iter_events()
-    got = await asyncio.wait_for(it.__anext__(), timeout=1.0)
+    event_iter = client.iter_events()
+    got = await asyncio.wait_for(event_iter.__anext__(), timeout=1.0)
+
     assert got is msg
+    assert client._access_token == "newtoken"
+
+
+@pytest.mark.asyncio
+async def test_connect_creates_session_and_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session()
+
+    def _factory() -> _Session:
+        return session
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _factory)
+
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    async def _run_once() -> None:
+        client._running = False
+
+    client._run_supervisor = _run_once  # type: ignore[method-assign]
+
+    await client.connect()
+
+    assert client._session is session
+    assert client._supervisor_task is not None
+
+    await client._supervisor_task
+
+
+@pytest.mark.asyncio
+async def test_connect_is_noop_when_already_connected() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    task = asyncio.create_task(asyncio.sleep(0.01))
+    client._supervisor_task = task
+
+    await client.connect()
+
+    assert client._supervisor_task is task
+    await task
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_task_and_closes_session() -> None:
+    client = SignalRRTClient(_details(), access_token="secret", session=_Session())
+    client._running = True
+    client._supervisor_task = asyncio.create_task(asyncio.sleep(10))
+
+    await client.disconnect()
+
+    assert client._running is False
+    assert client._supervisor_task is None
+    assert client._session is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_without_task_or_session() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    await client.disconnect()
+
+    assert client._supervisor_task is None
+    assert client._session is None
+
+
+@pytest.mark.asyncio
+async def test_subscribe_and_unsubscribe_send_posts() -> None:
+    session = _Session(post_responses=[_Response(), _Response()])
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+
+    await client.subscribe("SERIAL1")
+    await client.unsubscribe("SERIAL1")
+
+    assert "SERIAL1" not in client._subscriptions
+    assert len(session.post_calls) == 2
+    assert session.post_calls[0]["url"].endswith("/subscribe")
+    assert session.post_calls[0]["json"] == {"serial": "SERIAL1"}
+    assert session.post_calls[1]["url"].endswith("/unsubscribe")
+
+
+@pytest.mark.asyncio
+async def test_send_subscribe_and_unsubscribe_no_session_noop() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    await client._send_subscribe("SERIAL1")
+    await client._send_unsubscribe("SERIAL1")
+
+    assert client._session is None
+
+
+@pytest.mark.asyncio
+async def test_run_supervisor_retries_after_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SignalRRTClient(
+        _details(),
+        access_token="secret",
+        reconnect_initial_delay=0.25,
+        reconnect_max_delay=1.0,
+    )
+    client._running = True
+    calls = {"connect": 0}
+    slept: list[float] = []
+
+    async def _connect_and_listen() -> None:
+        calls["connect"] += 1
+        if calls["connect"] == 1:
+            raise RuntimeError("fail once")
+        client._running = False
+
+    async def _sleep(delay: float) -> None:
+        slept.append(delay)
+
+    client._connect_and_listen = _connect_and_listen  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+    await client._run_supervisor()
+
+    assert calls["connect"] == 2
+    assert slept == [0.25]
+
+
+@pytest.mark.asyncio
+async def test_run_supervisor_stops_on_cancelled_error() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._running = True
+
+    async def _connect_and_listen() -> None:
+        raise asyncio.CancelledError
+
+    client._connect_and_listen = _connect_and_listen  # type: ignore[method-assign]
+
+    await client._run_supervisor()
+
+    assert client._running is True
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_requires_session() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    with pytest.raises(RuntimeError, match="no aiohttp session available"):
+        await client._connect_and_listen()
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_raises_when_sse_status_not_200() -> None:
+    session = _Session(get_responses=[_Response(status=500)])
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+    client._running = True
+
+    async def _negotiate() -> str:
+        return "https://example.test/signalr/connect"
+
+    client._negotiate = _negotiate  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="sse connect failed"):
+        await client._connect_and_listen()
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_fallback_when_negotiate_fails() -> None:
+    data = [b'data: {"x": 1}\n', b"\n"]
+    session = _Session(get_responses=[_Response(status=200, content_items=data)])
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+    client._running = True
+
+    async def _negotiate() -> str:
+        raise RuntimeError("negotiate failed")
+
+    seen: list[dict[str, object]] = []
+
+    def _handle_payload(payload: dict[str, object]) -> None:
+        seen.append(payload)
+        client._running = False
+
+    client._negotiate = _negotiate  # type: ignore[method-assign]
+    client._handle_payload = _handle_payload  # type: ignore[method-assign]
+
+    await client._connect_and_listen()
+
+    assert session.get_calls[0]["url"] == "https://example.test/signalr"
+    assert seen == [{"x": 1}]
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_handles_bad_decode_and_invalid_json() -> None:
+    data = [_BadRaw(), b"data: not-json\n", b"\n"]
+    session = _Session(get_responses=[_Response(status=200, content_items=data)])
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+    client._running = True
+
+    async def _negotiate() -> str:
+        return "https://example.test/signalr/connect"
+
+    client._negotiate = _negotiate  # type: ignore[method-assign]
+
+    await client._connect_and_listen()
+
+    assert session.get_calls[0]["url"] == "https://example.test/signalr/connect"
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_breaks_when_not_running() -> None:
+    data = [b'data: {"x": 1}\n', b"\n"]
+    session = _Session(get_responses=[_Response(status=200, content_items=data)])
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+    client._running = False
+
+    async def _negotiate() -> str:
+        return "https://example.test/signalr/connect"
+
+    seen: list[dict[str, object]] = []
+
+    def _handle_payload(payload: dict[str, object]) -> None:
+        seen.append(payload)
+
+    client._negotiate = _negotiate  # type: ignore[method-assign]
+    client._handle_payload = _handle_payload  # type: ignore[method-assign]
+
+    await client._connect_and_listen()
+
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_negotiate_requires_session() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    with pytest.raises(RuntimeError, match="no aiohttp session available"):
+        await client._negotiate()
+
+
+@pytest.mark.asyncio
+async def test_negotiate_raises_on_non_200() -> None:
+    session = _Session(post_responses=[_Response(status=401, json_data={})])
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+
+    with pytest.raises(RuntimeError, match="negotiate failed: 401"):
+        await client._negotiate()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"url": "https://example.test/signalr/sse"}, "https://example.test/signalr/sse"),
+        (
+            {"connectionId": "cid-1"},
+            "https://example.test/signalr/?id=cid-1&transport=serverSentEvents",
+        ),
+        (
+            {"connectionToken": "tok-1"},
+            "https://example.test/signalr/?transport=serverSentEvents&connectionToken=tok-1",
+        ),
+        ({"other": "value"}, "https://example.test/signalr"),
+    ],
+)
+async def test_negotiate_url_variants(payload: dict[str, str], expected: str) -> None:
+    session = _Session(post_responses=[_Response(status=200, json_data=payload)])
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+
+    got = await client._negotiate()
+
+    assert got == expected
+
+
+@pytest.mark.asyncio
+async def test_restore_subscriptions_invokes_send_subscribe() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._subscriptions = {"A", "B"}
+    sent: list[str] = []
+
+    async def _send(serial: str) -> None:
+        sent.append(serial)
+
+    client._send_subscribe = _send  # type: ignore[method-assign]
+
+    await client._restore_subscriptions()
+
+    assert sorted(sent) == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_restore_subscriptions_ignores_send_errors() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._subscriptions = {"A"}
+
+    async def _send(_: str) -> None:
+        raise RuntimeError("boom")
+
+    client._send_subscribe = _send  # type: ignore[method-assign]
+
+    await client._restore_subscriptions()
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_status_parse_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    payload = {
+        "Status": {
+            "isOn": True,
+            "lastKnownState": {
+                "UserAirconSettings": {
+                    "isOn": True,
+                    "Mode": "COOL",
+                    "FanMode": "LOW",
+                    "TemperatureSetpoint_Cool_oC": 22,
+                    "TemperatureSetpoint_Heat_oC": 20,
+                }
+            },
+            "MasterInfo": {},
+            "Alerts": {},
+            "RemoteZoneInfo": [],
+            "SystemStatus_Local": {},
+            "LiveAircon": {},
+            "AirconSystem": {},
+        }
+    }
+
+    seen: list[RealtimeEvent] = []
+
+    async def _emit(ev: RealtimeEvent) -> None:
+        seen.append(ev)
+
+    client._emit_event = _emit  # type: ignore[method-assign]
+
+    created: list[asyncio.Task[Any]] = []
+    real_create_task = asyncio.create_task
+
+    def _capture(coro: Any) -> asyncio.Task[Any]:
+        task = real_create_task(coro)
+        created.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _capture)
+
+    client._handle_payload(payload)
+    await asyncio.gather(*created)
+
+    assert len(seen) == 1
+    msg = seen[0]
+    assert isinstance(msg, RealtimeMessage)
+    assert msg.payload == payload
+    assert msg.domain_model is not None
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_status_parse_failure_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    payload = {"Status": {"bad": object()}}
+    seen: list[RealtimeEvent] = []
+
+    async def _emit(ev: RealtimeEvent) -> None:
+        seen.append(ev)
+
+    client._emit_event = _emit  # type: ignore[method-assign]
+
+    created: list[asyncio.Task[Any]] = []
+    real_create_task = asyncio.create_task
+
+    def _capture(coro: Any) -> asyncio.Task[Any]:
+        task = real_create_task(coro)
+        created.append(task)
+        return task
+
+    def _raise_validate(_: Any) -> Any:
+        raise ValueError("invalid status payload")
+
+    monkeypatch.setattr(
+        "actron_neo_api.models.status.ActronAirStatus.model_validate",
+        _raise_validate,
+    )
+    monkeypatch.setattr(asyncio, "create_task", _capture)
+
+    client._handle_payload(payload)
+    await asyncio.gather(*created)
+
+    assert len(seen) == 1
+    msg = seen[0]
+    assert isinstance(msg, RealtimeMessage)
+    assert msg.domain_model == payload
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_without_status_uses_raw_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    payload = {"a": 1}
+    seen: list[RealtimeEvent] = []
+
+    async def _emit(ev: RealtimeEvent) -> None:
+        seen.append(ev)
+
+    client._emit_event = _emit  # type: ignore[method-assign]
+
+    created: list[asyncio.Task[Any]] = []
+    real_create_task = asyncio.create_task
+
+    def _capture(coro: Any) -> asyncio.Task[Any]:
+        task = real_create_task(coro)
+        created.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _capture)
+
+    client._handle_payload(payload)
+    await asyncio.gather(*created)
+
+    assert len(seen) == 1
+    msg = seen[0]
+    assert isinstance(msg, RealtimeMessage)
+    assert msg.domain_model == payload
+
+
+@pytest.mark.asyncio
+async def test_handle_payload_outer_exception_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    def _raise(coro: Any) -> None:
+        coro.close()
+        raise RuntimeError("create task failed")
+
+    monkeypatch.setattr(asyncio, "create_task", _raise)
+
+    # The method should swallow/log the failure and not raise.
+    client._handle_payload({"a": 1})

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -10,7 +10,12 @@ from actron_neo_api.rt import RealtimeConnectionDetails, SignalRRTClient
 
 
 def test_register_callback_and_emit(tmp_path) -> None:
-    details = RealtimeConnectionDetails(endpoint="https://example.test/signalr", port=443, protocol="https", user_id="u")
+    details = RealtimeConnectionDetails(
+        endpoint="https://example.test/signalr",
+        port=443,
+        protocol="https",
+        user_id="u",
+    )
     client = SignalRRTClient(details, access_token="secret")
 
     seen: list = []
@@ -20,11 +25,20 @@ def test_register_callback_and_emit(tmp_path) -> None:
 
     client.register_callback(cb)
 
-    ev = type("E", (), {"message": type("M", (), {"domain_model": {"foo": "bar"}})})()
+    from actron_neo_api.rt.base import RealtimeEventKind, RealtimeMessage, RealtimeTransportType
+
+    msg = RealtimeMessage(
+        transport=RealtimeTransportType.SIGNALR,
+        kind=RealtimeEventKind.MESSAGE,
+        topic="signalr",
+        payload={"foo": "bar"},
+        raw_payload=None,
+        domain_model={"foo": "bar"},
+    )
 
     # schedule emit and consume from queue
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(client._emit_event(ev))
+    loop.run_until_complete(client._emit_event(msg))
 
     # callback should have been called and queue populated
     assert len(seen) == 1
@@ -32,16 +46,29 @@ def test_register_callback_and_emit(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_iter_events_and_update_token() -> None:
-    details = RealtimeConnectionDetails(endpoint="https://example.test/signalr", port=443, protocol="https", user_id="u")
+    details = RealtimeConnectionDetails(
+        endpoint="https://example.test/signalr",
+        port=443,
+        protocol="https",
+        user_id="u",
+    )
     client = SignalRRTClient(details, access_token="oldtoken")
 
-    # put a fake event onto the queue
-    ev = type("E", (), {"message": type("M", (), {"domain_model": {"k": "v"}})})()
-    await client._emit_event(ev)
+    from actron_neo_api.rt.base import RealtimeEventKind, RealtimeMessage, RealtimeTransportType
+
+    msg = RealtimeMessage(
+        transport=RealtimeTransportType.SIGNALR,
+        kind=RealtimeEventKind.MESSAGE,
+        topic="signalr",
+        payload={"k": "v"},
+        raw_payload=None,
+        domain_model={"k": "v"},
+    )
+    await client._emit_event(msg)
 
     # update token should not raise
     await client.update_access_token("newtoken")
 
     it = client.iter_events()
     got = await asyncio.wait_for(it.__anext__(), timeout=1.0)
-    assert got is ev
+    assert got is msg

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -9,7 +9,10 @@ import pytest
 from actron_neo_api.rt import RealtimeConnectionDetails, SignalRRTClient
 
 
-def test_register_callback_and_emit(tmp_path) -> None:
+import pytest
+
+@pytest.mark.asyncio
+async def test_register_callback_and_emit(tmp_path) -> None:
     details = RealtimeConnectionDetails(
         endpoint="https://example.test/signalr",
         port=443,
@@ -37,8 +40,7 @@ def test_register_callback_and_emit(tmp_path) -> None:
     )
 
     # schedule emit and consume from queue
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(client._emit_event(msg))
+    await client._emit_event(msg)
 
     # callback should have been called and queue populated
     assert len(seen) == 1

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -207,8 +207,34 @@ async def test_connect_is_noop_when_already_connected() -> None:
 
 
 @pytest.mark.asyncio
+async def test_connect_restarts_when_previous_task_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session()
+
+    def _factory() -> _Session:
+        return session
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _factory)
+
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._supervisor_task = asyncio.create_task(asyncio.sleep(0))
+    await client._supervisor_task
+
+    async def _run_once() -> None:
+        client._running = False
+
+    client._run_supervisor = _run_once  # type: ignore[method-assign]
+
+    await client.connect()
+
+    assert client._supervisor_task is not None
+    await client._supervisor_task
+
+
+@pytest.mark.asyncio
 async def test_disconnect_cancels_task_and_closes_session() -> None:
-    client = SignalRRTClient(_details(), access_token="secret", session=_Session())
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._session = _Session()
+    client._external_session = False
     client._running = True
     client._supervisor_task = asyncio.create_task(asyncio.sleep(10))
 
@@ -220,6 +246,17 @@ async def test_disconnect_cancels_task_and_closes_session() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disconnect_does_not_close_external_session() -> None:
+    session = _Session()
+    client = SignalRRTClient(_details(), access_token="secret", session=session)
+
+    await client.disconnect()
+
+    assert session.closed is False
+    assert client._session is session
+
+
+@pytest.mark.asyncio
 async def test_disconnect_without_task_or_session() -> None:
     client = SignalRRTClient(_details(), access_token="secret")
 
@@ -227,6 +264,17 @@ async def test_disconnect_without_task_or_session() -> None:
 
     assert client._supervisor_task is None
     assert client._session is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_resubscribe_task() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._running = True
+    client._resubscribe_task = asyncio.create_task(asyncio.sleep(10))
+
+    await client.disconnect()
+
+    assert client._resubscribe_task is None
 
 
 @pytest.mark.asyncio
@@ -252,6 +300,17 @@ async def test_send_subscribe_and_unsubscribe_no_session_noop() -> None:
     await client._send_unsubscribe("SERIAL1")
 
     assert client._session is None
+
+
+@pytest.mark.asyncio
+async def test_subscribe_unsubscribe_empty_serial_rejected() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    with pytest.raises(ValueError, match="device_serial cannot be empty"):
+        await client.subscribe("  ")
+
+    with pytest.raises(ValueError, match="device_serial cannot be empty"):
+        await client.unsubscribe("")
 
 
 @pytest.mark.asyncio
@@ -281,6 +340,34 @@ async def test_run_supervisor_retries_after_failure(monkeypatch: pytest.MonkeyPa
     await client._run_supervisor()
 
     assert calls["connect"] == 2
+    assert slept == [0.25]
+
+
+@pytest.mark.asyncio
+async def test_run_supervisor_uses_backoff_when_stream_ends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SignalRRTClient(
+        _details(),
+        access_token="secret",
+        reconnect_initial_delay=0.25,
+        reconnect_max_delay=1.0,
+    )
+    client._running = True
+    slept: list[float] = []
+
+    async def _connect_and_listen() -> None:
+        return None
+
+    async def _sleep(delay: float) -> None:
+        slept.append(delay)
+        client._running = False
+
+    client._connect_and_listen = _connect_and_listen  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+    await client._run_supervisor()
+
     assert slept == [0.25]
 
 
@@ -405,6 +492,60 @@ async def test_negotiate_raises_on_non_200() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_access_token_validates_and_normalizes() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    with pytest.raises(ValueError, match="access_token cannot be empty"):
+        await client.update_access_token("  ")
+
+    await client.update_access_token(" next-token ")
+    assert client._access_token == "next-token"
+
+
+@pytest.mark.asyncio
+async def test_iter_events_returns_when_not_running_and_empty() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    items = [item async for item in client.iter_events()]
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_publish_not_supported() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    with pytest.raises(NotImplementedError, match="does not support publish"):
+        await client.publish("topic", {"x": 1})
+
+
+@pytest.mark.parametrize(
+    ("access_token", "initial_delay", "max_delay", "error_match"),
+    [
+        ("", 1.0, 30.0, "access_token cannot be empty"),
+        ("secret", 0.0, 30.0, "reconnect_initial_delay must be greater than zero"),
+        (
+            "secret",
+            2.0,
+            1.0,
+            "reconnect_max_delay must be greater than or equal to initial delay",
+        ),
+    ],
+)
+def test_constructor_validation(
+    access_token: str,
+    initial_delay: float,
+    max_delay: float,
+    error_match: str,
+) -> None:
+    with pytest.raises(ValueError, match=error_match):
+        SignalRRTClient(
+            _details(),
+            access_token=access_token,
+            reconnect_initial_delay=initial_delay,
+            reconnect_max_delay=max_delay,
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
@@ -456,6 +597,51 @@ async def test_restore_subscriptions_ignores_send_errors() -> None:
     client._send_subscribe = _send  # type: ignore[method-assign]
 
     await client._restore_subscriptions()
+
+
+@pytest.mark.asyncio
+async def test_run_subscription_refresh_breaks_after_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._running = True
+    restored = {"count": 0}
+
+    async def _sleep(_: float) -> None:
+        client._running = False
+
+    async def _restore() -> None:
+        restored["count"] += 1
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    client._restore_subscriptions = _restore  # type: ignore[method-assign]
+
+    await client._run_subscription_refresh()
+
+    assert restored["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_subscription_refresh_calls_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    client._running = True
+    restored = {"count": 0}
+
+    async def _sleep(_: float) -> None:
+        return None
+
+    async def _restore() -> None:
+        restored["count"] += 1
+        client._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    client._restore_subscriptions = _restore  # type: ignore[method-assign]
+
+    await client._run_subscription_refresh()
+
+    assert restored["count"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds a minimal SignalR-over-SSE realtime client for Que systems (src/actron_neo_api/rt/signalr_client.py), exposes SignalRRTClient from the rt package, and includes unit tests (tests/test_signalr_client.py). The implementation is intentionally lightweight and focuses on connect/subscribe/reconnect semantics and mapping incoming payloads to existing domain models.

Tests: added basic emission/queue tests and updated package export tests. All tests pass locally.