### PR TITLE
feat: integrate realtime push into public API (#77)

### DIFF
--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, Literal
 
 import aiohttp
@@ -30,6 +30,13 @@ from .models import (
     ActronAirUserInfo,
 )
 from .oauth import ActronAirOAuth2DeviceCodeAuth
+from .rt import (
+    MQTTRTClient,
+    RealtimeConnectionDetails,
+    RealtimeEvent,
+    RealtimeMessage,
+    SignalRRTClient,
+)
 from .state import StateManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -316,6 +323,14 @@ class ActronAirAPI:
             debounce_seconds=debounce_seconds,
         )
 
+        # Realtime push integration (issue #77)
+        self._rt_client: MQTTRTClient | SignalRRTClient | None = None
+        self._push_running = False
+        self._push_status_queue: asyncio.Queue[tuple[str, ActronAirStatus]] = asyncio.Queue()
+        self._push_callbacks: dict[
+            str, list[Callable[[ActronAirStatus], Awaitable[None] | None]]
+        ] = {}
+
     @property
     def platform(self) -> str:
         """Get the current platform being used.
@@ -484,11 +499,277 @@ class ActronAirAPI:
             closed — the caller retains ownership.
 
         """
+        await self.stop_push()
         await self._coalescer.flush_all()
         async with self._session_lock:
             if self._session and not self._session.closed and not self._external_session:
                 await self._session.close()
                 self._session = None
+
+    async def start_push(
+        self,
+        serial_numbers: list[str] | None = None,
+        *,
+        connection_details: RealtimeConnectionDetails | None = None,
+    ) -> bool:
+        """Start realtime push updates for one or more systems.
+
+        Args:
+            serial_numbers: Optional list of system serial numbers to subscribe.
+                If omitted, subscribes all known systems (fetching systems if needed).
+            connection_details: Optional pre-resolved realtime connection details.
+                If omitted, the client attempts to discover details from API links.
+
+        Returns:
+            True if realtime push started successfully, otherwise False.
+        """
+        if self._rt_client is not None and self._push_running:
+            return True
+
+        await self._ensure_initialized()
+        await self.oauth2_auth.ensure_token_valid()
+
+        serials: list[str]
+        if serial_numbers:
+            serials = [serial.strip().lower() for serial in serial_numbers if serial.strip()]
+        else:
+            if not self.systems:
+                await self.get_ac_systems()
+            serials = [system.serial.lower() for system in self.systems if system.serial]
+
+        if not serials:
+            _LOGGER.warning("start_push called without any known system serials")
+            return False
+
+        try:
+            details = connection_details or await self._discover_realtime_connection_details(
+                serials[0]
+            )
+            if details is None:
+                _LOGGER.warning("Realtime connection details unavailable; push not started")
+                return False
+
+            token = self.oauth2_auth.access_token
+            if not token:
+                raise ActronAirAuthError("No OAuth access token available for realtime transport")
+
+            if self.platform == PLATFORM_QUE:
+                rt_client: MQTTRTClient | SignalRRTClient = SignalRRTClient(details, token)
+            else:
+                rt_client = MQTTRTClient(details, token)
+
+            def _on_event(event: RealtimeEvent) -> None:
+                task = asyncio.create_task(self._handle_realtime_event(event))
+                task.add_done_callback(self._log_background_task_error)
+
+            rt_client.register_callback(_on_event)
+
+            await rt_client.connect()
+            for serial in serials:
+                if isinstance(rt_client, MQTTRTClient):
+                    await rt_client.subscribe_system(serial)
+                else:
+                    await rt_client.subscribe(serial)
+
+            self._rt_client = rt_client
+            self._push_running = True
+            return True
+        except Exception:
+            _LOGGER.exception("Failed to start realtime push; falling back to polling")
+            if self._rt_client is not None:
+                try:
+                    await self._rt_client.disconnect()
+                except Exception:
+                    _LOGGER.debug("Failed to clean up realtime client", exc_info=True)
+            self._rt_client = None
+            self._push_running = False
+            return False
+
+    async def stop_push(self) -> None:
+        """Stop realtime push updates and disconnect active transport."""
+        self._push_running = False
+        if self._rt_client is None:
+            return
+        try:
+            await self._rt_client.disconnect()
+        finally:
+            self._rt_client = None
+
+    def subscribe_system_updates(
+        self,
+        serial_number: str,
+        callback: Callable[[ActronAirStatus], Awaitable[None] | None],
+    ) -> None:
+        """Register a callback for status updates of a specific system.
+
+        Args:
+            serial_number: Target system serial number.
+            callback: Callback invoked with each parsed status update.
+
+        Raises:
+            ValueError: If serial_number is empty.
+        """
+        serial = serial_number.strip().lower()
+        if not serial:
+            raise ValueError("serial_number cannot be empty")
+        self._push_callbacks.setdefault(serial, []).append(callback)
+
+    async def stream_system_updates(
+        self,
+        serial_number: str | None = None,
+    ) -> AsyncIterator[ActronAirStatus]:
+        """Yield parsed push status updates as they arrive.
+
+        Args:
+            serial_number: Optional serial filter. If set, only matching
+                statuses are yielded.
+        """
+        serial_filter = serial_number.strip().lower() if serial_number else None
+        while self._push_running or not self._push_status_queue.empty():
+            serial, status = await self._push_status_queue.get()
+            if serial_filter and serial != serial_filter:
+                continue
+            yield status
+
+    @staticmethod
+    def _log_background_task_error(task: asyncio.Task[None]) -> None:
+        """Log unhandled exceptions from background tasks."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            _LOGGER.error(
+                "Realtime event task failed", exc_info=(type(exc), exc, exc.__traceback__)
+            )
+
+    async def _discover_realtime_connection_details(
+        self,
+        serial_number: str,
+    ) -> RealtimeConnectionDetails | None:
+        """Discover realtime connection details from API links or platform defaults."""
+        rel_candidates = (
+            "rtc-details",
+            "rtc",
+            "realtime",
+            "messaging",
+            "mqtt",
+        )
+        for rel in rel_candidates:
+            endpoint = self._get_system_link(serial_number, rel)
+            if endpoint:
+                try:
+                    payload = await self._make_request("get", endpoint)
+                    details = self._parse_realtime_details_payload(payload)
+                    if details is not None:
+                        return details
+                except Exception:
+                    _LOGGER.debug("Realtime details link %s lookup failed", rel, exc_info=True)
+
+        # Que fallback endpoint from documented SignalR path.
+        if self.platform == PLATFORM_QUE:
+            return RealtimeConnectionDetails(
+                endpoint=f"{self.base_url.rstrip('/')}/api/v0/messaging/app",
+                port=443,
+                protocol="https",
+                user_id="unknown",
+            )
+
+        return None
+
+    def _parse_realtime_details_payload(
+        self,
+        payload: dict[str, Any],
+    ) -> RealtimeConnectionDetails | None:
+        """Parse API payload into RealtimeConnectionDetails."""
+        candidate = payload
+        if isinstance(payload.get("RTCDetails"), dict):
+            candidate = payload["RTCDetails"]
+        elif isinstance(payload.get("rtcDetails"), dict):
+            candidate = payload["rtcDetails"]
+
+        endpoint = self._pick_str(candidate, "endPoint", "endpoint", "host", "server")
+        user_id = self._pick_str(candidate, "userId", "user_id", "username") or "unknown"
+
+        if not endpoint:
+            return None
+
+        raw_port = candidate.get("port")
+        port = int(raw_port) if isinstance(raw_port, int | str) and str(raw_port).isdigit() else 443
+        protocol = self._pick_str(candidate, "protocol", "scheme") or "ssl"
+
+        return RealtimeConnectionDetails(
+            endpoint=endpoint,
+            port=port,
+            protocol=protocol,
+            user_id=user_id,
+        )
+
+    @staticmethod
+    def _pick_str(source: dict[str, Any], *keys: str) -> str | None:
+        """Return the first non-empty string value from source for keys."""
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    async def _handle_realtime_event(self, event: RealtimeEvent) -> None:
+        """Process an incoming realtime event from active transport."""
+        if not isinstance(event, RealtimeMessage):
+            return
+
+        if not isinstance(event.domain_model, ActronAirStatus):
+            return
+
+        status = event.domain_model
+        serial = self._extract_realtime_serial(event, status)
+        if not serial:
+            return
+
+        status.serial_number = serial
+        self.state_manager.process_status_update(serial, status)
+        await self._push_status_queue.put((serial, status))
+
+        for callback in list(self._push_callbacks.get(serial, [])):
+            result = callback(status)
+            if asyncio.iscoroutine(result):
+                await result
+
+    @staticmethod
+    def _extract_realtime_serial(
+        event: RealtimeMessage,
+        status: ActronAirStatus,
+    ) -> str | None:
+        """Extract system serial from status model or transport-specific metadata."""
+        if status.serial_number:
+            return status.serial_number.lower()
+
+        topic_parts = event.topic.split("/")
+        if len(topic_parts) >= 4 and topic_parts[0] == "actron-cloud":
+            return topic_parts[3].lower()
+
+        candidates = (
+            event.payload.get("serial"),
+            event.payload.get("serialNumber"),
+            event.payload.get("SerialNumber"),
+        )
+        for value in candidates:
+            if isinstance(value, str) and value.strip():
+                return value.strip().lower()
+
+        return None
+
+    async def _sync_realtime_access_token(self) -> None:
+        """Push latest access token to active realtime transport."""
+        if self._rt_client is None:
+            return
+        token = self.oauth2_auth.access_token
+        if not token:
+            return
+        try:
+            await self._rt_client.update_access_token(token)
+        except Exception:
+            _LOGGER.debug("Failed to update realtime access token", exc_info=True)
 
     async def __aenter__(self) -> "ActronAirAPI":
         """Support for async context manager."""
@@ -557,6 +838,7 @@ class ActronAirAPI:
 
         # Ensure we have a valid token
         await self.oauth2_auth.ensure_token_valid()
+        await self._sync_realtime_access_token()
 
         auth_header = self.oauth2_auth.authorization_header
 
@@ -581,6 +863,7 @@ class ActronAirAPI:
                     if _retry and self.oauth2_auth.refresh_token:
                         try:
                             await self.oauth2_auth.refresh_access_token()
+                            await self._sync_realtime_access_token()
                             return await self._make_request(
                                 method, endpoint, params, json_data, data, headers, _retry=False
                             )

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -328,6 +328,9 @@ class ActronAirAPI:
         self._rt_client: MQTTRTClient | SignalRRTClient | None = None
         self._push_running = False
         self._push_status_queue: asyncio.Queue[tuple[str, ActronAirStatus | None]] = asyncio.Queue()
+        self._push_stream_queues: list[
+            tuple[str | None, asyncio.Queue[ActronAirStatus | None]]
+        ] = []
         self._push_callbacks: dict[
             str, list[Callable[[ActronAirStatus], Awaitable[None] | None]]
         ] = {}
@@ -556,9 +559,12 @@ class ActronAirAPI:
                 raise ActronAirAuthError("No OAuth access token available for realtime transport")
 
             if self.platform == PLATFORM_QUE:
-                rt_client: MQTTRTClient | SignalRRTClient = SignalRRTClient(details, token)
+                rt_client = SignalRRTClient(details, token)
             else:
                 rt_client = MQTTRTClient(details, token)
+
+            if rt_client is None:
+                raise ActronAirAPIError("Failed to create realtime transport client")
 
             def _on_event(event: RealtimeEvent) -> None:
                 task = asyncio.create_task(self._handle_realtime_event(event))
@@ -593,6 +599,8 @@ class ActronAirAPI:
         self._push_running = False
         # Wake blocked stream consumers so they can exit cleanly.
         self._push_status_queue.put_nowait(("", None))
+        for _, stream_queue in list(self._push_stream_queues):
+            stream_queue.put_nowait(None)
         if self._rt_client is None:
             return
         try:
@@ -630,13 +638,19 @@ class ActronAirAPI:
                 statuses are yielded.
         """
         serial_filter = serial_number.strip().lower() if serial_number else None
-        while True:
-            serial, status = await self._push_status_queue.get()
-            if status is None:
-                break
-            if serial_filter and serial != serial_filter:
-                continue
-            yield status
+        stream_queue: asyncio.Queue[ActronAirStatus | None] = asyncio.Queue()
+        self._push_stream_queues.append((serial_filter, stream_queue))
+
+        try:
+            while self._push_running or not stream_queue.empty():
+                status = await stream_queue.get()
+                if status is None:
+                    break
+                yield status
+        finally:
+            self._push_stream_queues = [
+                (flt, queue) for flt, queue in self._push_stream_queues if queue is not stream_queue
+            ]
 
     @staticmethod
     def _log_background_task_error(task: asyncio.Task[None]) -> None:
@@ -736,6 +750,9 @@ class ActronAirAPI:
         status.serial_number = serial
         self.state_manager.process_status_update(serial, status)
         await self._push_status_queue.put((serial, status))
+        for stream_filter, stream_queue in list(self._push_stream_queues):
+            if stream_filter is None or stream_filter == serial:
+                stream_queue.put_nowait(status)
 
         for callback in list(self._push_callbacks.get(serial, [])):
             try:

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, Literal
@@ -326,7 +327,7 @@ class ActronAirAPI:
         # Realtime push integration (issue #77)
         self._rt_client: MQTTRTClient | SignalRRTClient | None = None
         self._push_running = False
-        self._push_status_queue: asyncio.Queue[tuple[str, ActronAirStatus]] = asyncio.Queue()
+        self._push_status_queue: asyncio.Queue[tuple[str, ActronAirStatus | None]] = asyncio.Queue()
         self._push_callbacks: dict[
             str, list[Callable[[ActronAirStatus], Awaitable[None] | None]]
         ] = {}
@@ -541,6 +542,7 @@ class ActronAirAPI:
             _LOGGER.warning("start_push called without any known system serials")
             return False
 
+        rt_client: MQTTRTClient | SignalRRTClient | None = None
         try:
             details = connection_details or await self._discover_realtime_connection_details(
                 serials[0]
@@ -576,9 +578,10 @@ class ActronAirAPI:
             return True
         except Exception:
             _LOGGER.exception("Failed to start realtime push; falling back to polling")
-            if self._rt_client is not None:
+            cleanup_client = self._rt_client or rt_client
+            if cleanup_client is not None:
                 try:
-                    await self._rt_client.disconnect()
+                    await cleanup_client.disconnect()
                 except Exception:
                     _LOGGER.debug("Failed to clean up realtime client", exc_info=True)
             self._rt_client = None
@@ -588,6 +591,8 @@ class ActronAirAPI:
     async def stop_push(self) -> None:
         """Stop realtime push updates and disconnect active transport."""
         self._push_running = False
+        # Wake blocked stream consumers so they can exit cleanly.
+        self._push_status_queue.put_nowait(("", None))
         if self._rt_client is None:
             return
         try:
@@ -625,8 +630,10 @@ class ActronAirAPI:
                 statuses are yielded.
         """
         serial_filter = serial_number.strip().lower() if serial_number else None
-        while self._push_running or not self._push_status_queue.empty():
+        while True:
             serial, status = await self._push_status_queue.get()
+            if status is None:
+                break
             if serial_filter and serial != serial_filter:
                 continue
             yield status
@@ -731,9 +738,17 @@ class ActronAirAPI:
         await self._push_status_queue.put((serial, status))
 
         for callback in list(self._push_callbacks.get(serial, [])):
-            result = callback(status)
-            if asyncio.iscoroutine(result):
-                await result
+            try:
+                result = callback(status)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as err:
+                _LOGGER.warning(
+                    "Realtime callback failed for %s: %s",
+                    serial,
+                    err,
+                    exc_info=True,
+                )
 
     @staticmethod
     def _extract_realtime_serial(

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -1122,10 +1122,14 @@ class TestActronAirAPIRealtimeIntegration:
             domain_model=status,
         )
 
-        await api._handle_realtime_event(event)
-        api._push_running = False
+        async def _collect() -> list[ActronAirStatus]:
+            return [item async for item in api.stream_system_updates("abc123")]
 
-        streamed = [item async for item in api.stream_system_updates("abc123")]
+        collector = asyncio.create_task(_collect())
+        await asyncio.sleep(0)
+        await api._handle_realtime_event(event)
+        await api.stop_push()
+        streamed = await collector
 
         assert len(streamed) == 1
         assert streamed[0].serial_number == "abc123"
@@ -1382,16 +1386,39 @@ class TestActronAirAPIRealtimeIntegration:
     ) -> None:
         """stream_system_updates should filter by serial when requested."""
         api = ActronAirAPI()
+        api._push_running = True
         status1 = ActronAirStatus.model_validate(sample_status_full)
         status1.serial_number = "abc123"
         status2 = ActronAirStatus.model_validate(sample_status_full)
         status2.serial_number = "xyz789"
 
-        await api._push_status_queue.put(("xyz789", status2))
-        await api._push_status_queue.put(("abc123", status1))
-        api._push_running = False
+        async def _collect() -> list[ActronAirStatus]:
+            return [item async for item in api.stream_system_updates("abc123")]
 
-        streamed = [item async for item in api.stream_system_updates("abc123")]
+        collector = asyncio.create_task(_collect())
+        await asyncio.sleep(0)
+
+        await api._handle_realtime_event(
+            RealtimeMessage(
+                transport=RealtimeTransportType.MQTT,
+                kind=RealtimeEventKind.MESSAGE,
+                topic="actron-cloud/u/neo/xyz789/mwc/full-status",
+                payload={},
+                domain_model=status2,
+            )
+        )
+        await api._handle_realtime_event(
+            RealtimeMessage(
+                transport=RealtimeTransportType.MQTT,
+                kind=RealtimeEventKind.MESSAGE,
+                topic="actron-cloud/u/neo/abc123/mwc/full-status",
+                payload={},
+                domain_model=status1,
+            )
+        )
+
+        await api.stop_push()
+        streamed = await collector
 
         assert len(streamed) == 1
         assert streamed[0].serial_number == "abc123"

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -1262,6 +1262,55 @@ class TestActronAirAPIRealtimeIntegration:
         assert api._rt_client is None
 
     @pytest.mark.asyncio
+    async def test_start_push_cleans_up_local_client_on_subscribe_failure(self) -> None:
+        """start_push should disconnect newly-created client when subscribe fails."""
+
+        class FakeMQTTClient:
+            instances: list["FakeMQTTClient"] = []
+
+            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+                self.disconnect = AsyncMock(return_value=None)
+                FakeMQTTClient.instances.append(self)
+
+            def register_callback(self, callback: Any) -> None:
+                self.callback = callback
+
+            async def connect(self) -> None:
+                return None
+
+            async def subscribe_system(self, serial: str) -> None:
+                raise RuntimeError("subscribe failed")
+
+            async def update_access_token(self, token: str) -> None:
+                return None
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test",
+            port=8883,
+            protocol="ssl",
+            user_id="u",
+        )
+
+        from actron_neo_api import actron as actron_module
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = FakeMQTTClient  # type: ignore[assignment]
+            started = await api.start_push(connection_details=details)
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert started is False
+        assert api._rt_client is None
+        assert len(FakeMQTTClient.instances) == 1
+        FakeMQTTClient.instances[0].disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_start_push_event_callback_creates_background_task(
         self, sample_status_full: dict[str, Any]
     ) -> None:
@@ -1346,6 +1395,21 @@ class TestActronAirAPIRealtimeIntegration:
 
         assert len(streamed) == 1
         assert streamed[0].serial_number == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_stream_system_updates_unblocks_on_stop_push(self) -> None:
+        """stream_system_updates should exit when stop_push is called while waiting."""
+        api = ActronAirAPI()
+
+        async def _collect() -> list[ActronAirStatus]:
+            return [item async for item in api.stream_system_updates("abc123")]
+
+        collector = asyncio.create_task(_collect())
+        await asyncio.sleep(0)
+        await api.stop_push()
+        streamed = await collector
+
+        assert streamed == []
 
     @pytest.mark.asyncio
     async def test_discover_realtime_details_success_and_fallback(self) -> None:
@@ -1463,6 +1527,10 @@ class TestActronAirAPIRealtimeIntegration:
             if s.serial_number:
                 seen.append(s.serial_number)
 
+        def _bad_cb(_: ActronAirStatus) -> None:
+            raise RuntimeError("callback boom")
+
+        api.subscribe_system_updates("abc123", _bad_cb)
         api.subscribe_system_updates("abc123", _cb)
         status_ok = ActronAirStatus.model_validate(sample_status_full)
         event_ok = RealtimeMessage(

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -1,5 +1,6 @@
 """Tests for ActronAirAPI core client functionality."""
 
+import asyncio
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -8,8 +9,20 @@ import pytest
 
 from actron_neo_api import ActronAirAPI
 from actron_neo_api.exceptions import ActronAirAPIError, ActronAirAuthError
-from actron_neo_api.models import ActronAirDeviceCode, ActronAirToken, ActronAirUserInfo
+from actron_neo_api.models import (
+    ActronAirDeviceCode,
+    ActronAirStatus,
+    ActronAirToken,
+    ActronAirUserInfo,
+)
 from actron_neo_api.models.system import ActronAirSystemInfo
+from actron_neo_api.rt.base import (
+    RealtimeConnectionDetails,
+    RealtimeEvent,
+    RealtimeEventKind,
+    RealtimeMessage,
+    RealtimeTransportType,
+)
 
 
 class TestActronAirAPIInitialization:
@@ -940,3 +953,601 @@ class TestActronAirAPIInjectableSession:
         api._set_base_url("https://que.actronair.com.au", "que")
 
         assert api.oauth2_auth._session is external_session
+
+
+class TestActronAirAPIRealtimeIntegration:
+    """Test issue #77 realtime public API integration."""
+
+    @pytest.mark.asyncio
+    async def test_start_push_selects_mqtt_for_neo(self) -> None:
+        """Neo platform should use the MQTT transport."""
+
+        class FakeMQTTClient:
+            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+                self.details = details
+                self.token = token
+                self.callbacks: list[Any] = []
+                self.subscribed: list[str] = []
+
+            def register_callback(self, callback: Any) -> None:
+                self.callbacks.append(callback)
+
+            async def connect(self) -> None:
+                return None
+
+            async def subscribe_system(self, serial: str) -> None:
+                self.subscribed.append(serial)
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def update_access_token(self, token: str) -> None:
+                self.token = token
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="ABC123")]
+
+        async def _discover(_: str) -> RealtimeConnectionDetails:
+            return RealtimeConnectionDetails(
+                endpoint="mqtt.example.test",
+                port=8883,
+                protocol="ssl",
+                user_id="u",
+            )
+
+        api._discover_realtime_connection_details = _discover  # type: ignore[method-assign]
+
+        from actron_neo_api import actron as actron_module
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = FakeMQTTClient  # type: ignore[assignment]
+            started = await api.start_push()
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert started is True
+        assert isinstance(api._rt_client, FakeMQTTClient)
+        assert api._rt_client.subscribed == ["abc123"]
+
+    @pytest.mark.asyncio
+    async def test_start_push_selects_signalr_for_que(self) -> None:
+        """Que platform should use the SignalR transport."""
+
+        class FakeSignalRClient:
+            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+                self.details = details
+                self.token = token
+                self.subscribed: list[str] = []
+
+            def register_callback(self, callback: Any) -> None:
+                self.callback = callback
+
+            async def connect(self) -> None:
+                return None
+
+            async def subscribe(self, serial: str) -> None:
+                self.subscribed.append(serial)
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def update_access_token(self, token: str) -> None:
+                self.token = token
+
+        api = ActronAirAPI(platform="que")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="xyz789")]
+
+        async def _discover(_: str) -> RealtimeConnectionDetails:
+            return RealtimeConnectionDetails(
+                endpoint="https://que.example.test/api/v0/messaging/app",
+                port=443,
+                protocol="https",
+                user_id="u",
+            )
+
+        api._discover_realtime_connection_details = _discover  # type: ignore[method-assign]
+
+        from actron_neo_api import actron as actron_module
+
+        original_signalr = actron_module.SignalRRTClient
+        try:
+            actron_module.SignalRRTClient = FakeSignalRClient  # type: ignore[assignment]
+            started = await api.start_push()
+        finally:
+            actron_module.SignalRRTClient = original_signalr  # type: ignore[assignment]
+
+        assert started is True
+        assert isinstance(api._rt_client, FakeSignalRClient)
+        assert api._rt_client.subscribed == ["xyz789"]
+
+    @pytest.mark.asyncio
+    async def test_start_push_returns_false_without_systems(self) -> None:
+        """start_push should fail gracefully when no systems are available."""
+        api = ActronAirAPI()
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.get_ac_systems = AsyncMock(return_value=[])
+
+        started = await api.start_push()
+
+        assert started is False
+
+    @pytest.mark.asyncio
+    async def test_stop_push_disconnects_transport(self) -> None:
+        """stop_push should disconnect and clear active transport."""
+
+        class FakeClient:
+            def __init__(self) -> None:
+                self.disconnect = AsyncMock(return_value=None)
+
+        api = ActronAirAPI()
+        client = FakeClient()
+        api._rt_client = client  # type: ignore[assignment]
+        api._push_running = True
+
+        await api.stop_push()
+
+        client.disconnect.assert_called_once()
+        assert api._rt_client is None
+        assert api._push_running is False
+
+    @pytest.mark.asyncio
+    async def test_subscribe_and_stream_system_updates(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """Callbacks and stream should receive parsed ActronAirStatus updates."""
+        api = ActronAirAPI()
+        api._push_running = True
+        seen: list[str] = []
+
+        def _cb(status: ActronAirStatus) -> None:
+            if status.serial_number:
+                seen.append(status.serial_number)
+
+        api.subscribe_system_updates("ABC123", _cb)
+
+        status = ActronAirStatus.model_validate(sample_status_full)
+        status.serial_number = "abc123"
+        event = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/full-status",
+            payload={},
+            raw_payload=None,
+            domain_model=status,
+        )
+
+        await api._handle_realtime_event(event)
+        api._push_running = False
+
+        streamed = [item async for item in api.stream_system_updates("abc123")]
+
+        assert len(streamed) == 1
+        assert streamed[0].serial_number == "abc123"
+        assert seen == ["abc123"]
+
+    @pytest.mark.asyncio
+    async def test_make_request_syncs_realtime_token(
+        self,
+        mock_session: AsyncMock,
+        mock_aiohttp_response: Any,
+        mock_oauth: AsyncMock,
+    ) -> None:
+        """_make_request should push refreshed/access token to realtime transport."""
+
+        class FakeClient:
+            def __init__(self) -> None:
+                self.update_access_token = AsyncMock(return_value=None)
+
+        api = ActronAirAPI(refresh_token="test_token")
+        api._initialized = True
+        api._session = mock_session
+        api.oauth2_auth = mock_oauth
+        api._rt_client = FakeClient()  # type: ignore[assignment]
+
+        mock_session.request.return_value.__aenter__.return_value = mock_aiohttp_response(
+            status=200, json_data={"ok": True}
+        )
+
+        result = await api._make_request("get", "test/endpoint")
+
+        assert result["ok"] is True
+        api._rt_client.update_access_token.assert_called_once_with("test_access_token")
+
+    @pytest.mark.asyncio
+    async def test_start_push_returns_true_when_already_running(self) -> None:
+        """start_push should no-op when push is already active."""
+        api = ActronAirAPI()
+        api._push_running = True
+        api._rt_client = object()  # type: ignore[assignment]
+
+        started = await api.start_push()
+
+        assert started is True
+
+    @pytest.mark.asyncio
+    async def test_start_push_returns_false_when_details_unavailable(self) -> None:
+        """start_push should fallback when realtime details cannot be resolved."""
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        async def _discover(_: str) -> None:
+            return None
+
+        api._discover_realtime_connection_details = _discover  # type: ignore[method-assign]
+
+        started = await api.start_push()
+
+        assert started is False
+
+    @pytest.mark.asyncio
+    async def test_start_push_uses_explicit_serial_numbers(self) -> None:
+        """start_push should honor provided serial_numbers and ignore blanks."""
+
+        class FakeMQTTClient:
+            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+                self.subscribed: list[str] = []
+
+            def register_callback(self, callback: Any) -> None:
+                self.callback = callback
+
+            async def connect(self) -> None:
+                return None
+
+            async def subscribe_system(self, serial: str) -> None:
+                self.subscribed.append(serial)
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def update_access_token(self, token: str) -> None:
+                return None
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test",
+            port=8883,
+            protocol="ssl",
+            user_id="u",
+        )
+
+        from actron_neo_api import actron as actron_module
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = FakeMQTTClient  # type: ignore[assignment]
+            started = await api.start_push(
+                serial_numbers=["ABC123", "", "  "], connection_details=details
+            )
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert started is True
+        assert isinstance(api._rt_client, FakeMQTTClient)
+        assert api._rt_client.subscribed == ["abc123"]
+
+    @pytest.mark.asyncio
+    async def test_start_push_handles_missing_token_and_cleanup_error(self) -> None:
+        """start_push should handle auth failure and cleanup failures gracefully."""
+
+        class _OldClient:
+            async def disconnect(self) -> None:
+                raise RuntimeError("cleanup failed")
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = None
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+        api._rt_client = _OldClient()  # type: ignore[assignment]
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test",
+            port=8883,
+            protocol="ssl",
+            user_id="u",
+        )
+        started = await api.start_push(connection_details=details)
+
+        assert started is False
+        assert api._rt_client is None
+
+    @pytest.mark.asyncio
+    async def test_start_push_event_callback_creates_background_task(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """Registered transport callback should schedule event handling task."""
+
+        class FakeMQTTClient:
+            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+                self.callback: Any = None
+
+            def register_callback(self, callback: Any) -> None:
+                self.callback = callback
+
+            async def connect(self) -> None:
+                status = ActronAirStatus.model_validate(sample_status_full)
+                status.serial_number = "abc123"
+                event = RealtimeMessage(
+                    transport=RealtimeTransportType.MQTT,
+                    kind=RealtimeEventKind.MESSAGE,
+                    topic="actron-cloud/u/neo/abc123/mwc/full-status",
+                    payload={},
+                    domain_model=status,
+                )
+                if self.callback is not None:
+                    self.callback(event)
+
+            async def subscribe_system(self, serial: str) -> None:
+                return None
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def update_access_token(self, token: str) -> None:
+                return None
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test",
+            port=8883,
+            protocol="ssl",
+            user_id="u",
+        )
+
+        from actron_neo_api import actron as actron_module
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = FakeMQTTClient  # type: ignore[assignment]
+            started = await api.start_push(connection_details=details)
+            await asyncio.sleep(0)
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert started is True
+        assert api.state_manager.get_status("abc123") is not None
+
+    def test_subscribe_system_updates_empty_serial_raises(self) -> None:
+        """subscribe_system_updates should validate serial."""
+        api = ActronAirAPI()
+        with pytest.raises(ValueError, match="serial_number cannot be empty"):
+            api.subscribe_system_updates("", lambda _: None)
+
+    @pytest.mark.asyncio
+    async def test_stream_system_updates_skips_non_matching_serial(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """stream_system_updates should filter by serial when requested."""
+        api = ActronAirAPI()
+        status1 = ActronAirStatus.model_validate(sample_status_full)
+        status1.serial_number = "abc123"
+        status2 = ActronAirStatus.model_validate(sample_status_full)
+        status2.serial_number = "xyz789"
+
+        await api._push_status_queue.put(("xyz789", status2))
+        await api._push_status_queue.put(("abc123", status1))
+        api._push_running = False
+
+        streamed = [item async for item in api.stream_system_updates("abc123")]
+
+        assert len(streamed) == 1
+        assert streamed[0].serial_number == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_discover_realtime_details_success_and_fallback(self) -> None:
+        """Discovery should parse link payloads and Que fallback endpoint."""
+        api = ActronAirAPI(platform="neo")
+
+        def _link(_: str, rel: str) -> str | None:
+            return "api/v0/rtc" if rel == "rtc" else None
+
+        async def _req(_: str, endpoint: str) -> dict[str, Any]:
+            assert endpoint == "api/v0/rtc"
+            return {
+                "RTCDetails": {
+                    "endPoint": "broker.test",
+                    "port": 8883,
+                    "protocol": "ssl",
+                    "userId": "u",
+                }
+            }
+
+        api._get_system_link = _link  # type: ignore[method-assign]
+        api._make_request = _req  # type: ignore[method-assign]
+
+        details = await api._discover_realtime_connection_details("abc123")
+        assert details is not None
+        assert details.endpoint == "broker.test"
+
+        api_q = ActronAirAPI(platform="que")
+        api_q._get_system_link = lambda *_: None  # type: ignore[method-assign]
+        fallback = await api_q._discover_realtime_connection_details("xyz789")
+        assert fallback is not None
+        assert fallback.endpoint.endswith("/api/v0/messaging/app")
+
+    @pytest.mark.asyncio
+    async def test_discover_realtime_details_handles_lookup_exceptions(self) -> None:
+        """Discovery should continue when a link request fails."""
+        api = ActronAirAPI(platform="que")
+        api._get_system_link = lambda *_: "api/v0/rtc"  # type: ignore[method-assign]
+
+        async def _boom(_: str, __: str) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        api._make_request = _boom  # type: ignore[method-assign]
+
+        details = await api._discover_realtime_connection_details("xyz789")
+        assert details is not None
+
+    def test_parse_realtime_details_payload_variants(self) -> None:
+        """Realtime details payload parsing should support multiple key variants."""
+        api = ActronAirAPI()
+
+        parsed = api._parse_realtime_details_payload(
+            {
+                "rtcDetails": {
+                    "endpoint": "broker.test",
+                    "port": "1883",
+                    "scheme": "tcp",
+                    "username": "u",
+                }
+            }
+        )
+        assert parsed is not None
+        assert parsed.port == 1883
+        assert parsed.protocol == "tcp"
+        assert parsed.user_id == "u"
+
+        assert api._parse_realtime_details_payload({"RTCDetails": {"port": "bad"}}) is None
+        assert api._pick_str({"a": "", "b": " value "}, "a", "b") == "value"
+        assert api._pick_str({"a": ""}, "a") is None
+
+    @pytest.mark.asyncio
+    async def test_discover_realtime_details_returns_none_for_neo_without_links(self) -> None:
+        """Neo discovery should return None if no links/details are available."""
+        api = ActronAirAPI(platform="neo")
+        api._get_system_link = lambda *_: None  # type: ignore[method-assign]
+
+        details = await api._discover_realtime_connection_details("abc123")
+
+        assert details is None
+
+    @pytest.mark.asyncio
+    async def test_handle_realtime_event_branch_coverage(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """Handle event should ignore unsupported shapes and await async callbacks."""
+        api = ActronAirAPI()
+
+        await api._handle_realtime_event(
+            RealtimeEvent(transport=RealtimeTransportType.MQTT, kind=RealtimeEventKind.CONNECTION)
+        )
+
+        msg_no_status = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="x",
+            payload={},
+            domain_model={"not": "status"},
+        )
+        await api._handle_realtime_event(msg_no_status)
+
+        status = ActronAirStatus.model_validate(sample_status_full)
+        status.serial_number = None
+        msg_no_serial = RealtimeMessage(
+            transport=RealtimeTransportType.SIGNALR,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="signalr",
+            payload={},
+            domain_model=status,
+        )
+        await api._handle_realtime_event(msg_no_serial)
+
+        seen: list[str] = []
+
+        async def _cb(s: ActronAirStatus) -> None:
+            if s.serial_number:
+                seen.append(s.serial_number)
+
+        api.subscribe_system_updates("abc123", _cb)
+        status_ok = ActronAirStatus.model_validate(sample_status_full)
+        event_ok = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/full-status",
+            payload={"serial": "abc123"},
+            domain_model=status_ok,
+        )
+        await api._handle_realtime_event(event_ok)
+
+        assert seen == ["abc123"]
+
+    def test_extract_realtime_serial_from_topic_branch(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """Serial extraction should parse MQTT topic structure when status has no serial."""
+        status = ActronAirStatus.model_validate(sample_status_full)
+        status.serial_number = None
+        msg = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/full-status",
+            payload={},
+            domain_model=status,
+        )
+
+        assert ActronAirAPI._extract_realtime_serial(msg, status) == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_log_background_task_error_branches(self) -> None:
+        """Background task logger should handle both cancelled and failed tasks."""
+        cancelled = asyncio.create_task(asyncio.sleep(0.1))
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        ActronAirAPI._log_background_task_error(cancelled)
+
+        async def _boom() -> None:
+            raise RuntimeError("boom")
+
+        failed = asyncio.create_task(_boom())
+        with pytest.raises(RuntimeError, match="boom"):
+            await failed
+        ActronAirAPI._log_background_task_error(failed)
+
+    @pytest.mark.asyncio
+    async def test_sync_realtime_access_token_branches(self) -> None:
+        """Token sync should handle no-token and transport update failures."""
+
+        class _Client:
+            async def update_access_token(self, _: str) -> None:
+                raise RuntimeError("boom")
+
+        api = ActronAirAPI()
+        await api._sync_realtime_access_token()  # no client branch
+
+        api._rt_client = _Client()  # type: ignore[assignment]
+        api.oauth2_auth.access_token = None
+        await api._sync_realtime_access_token()  # no token branch
+
+        api.oauth2_auth.access_token = "token"
+        await api._sync_realtime_access_token()  # exception branch
+
+    def test_extract_realtime_serial_from_payload_and_none(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """Serial extraction should support payload keys and missing values."""
+        status = ActronAirStatus.model_validate(sample_status_full)
+        status.serial_number = None
+
+        msg_payload = RealtimeMessage(
+            transport=RealtimeTransportType.SIGNALR,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="signalr",
+            payload={"serialNumber": "ABC123"},
+            domain_model=status,
+        )
+        assert ActronAirAPI._extract_realtime_serial(msg_payload, status) == "abc123"
+
+        msg_none = RealtimeMessage(
+            transport=RealtimeTransportType.SIGNALR,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="signalr",
+            payload={},
+            domain_model=status,
+        )
+        assert ActronAirAPI._extract_realtime_serial(msg_none, status) is None

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -1241,6 +1241,33 @@ class TestActronAirAPIRealtimeIntegration:
         assert api._rt_client.subscribed == ["abc123"]
 
     @pytest.mark.asyncio
+    async def test_start_push_handles_missing_transport_instance(self) -> None:
+        """start_push should fail gracefully when transport creation returns None."""
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test",
+            port=8883,
+            protocol="ssl",
+            user_id="u",
+        )
+
+        from actron_neo_api import actron as actron_module
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = lambda *_args, **_kwargs: None  # type: ignore[assignment]
+            started = await api.start_push(connection_details=details)
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert started is False
+        assert api._rt_client is None
+
+    @pytest.mark.asyncio
     async def test_start_push_handles_missing_token_and_cleanup_error(self) -> None:
         """start_push should handle auth failure and cleanup failures gracefully."""
 


### PR DESCRIPTION
## Summary
Integrates issue #77 by wiring realtime transports into the public `ActronAirAPI` surface with platform-aware selection and lifecycle management.

## Changes
- Add public push APIs to `ActronAirAPI`:
  - `start_push()`
  - `stop_push()`
  - `subscribe_system_updates()`
  - `stream_system_updates()`
- Add transport orchestration in `ActronAirAPI`:
  - Auto-select `MQTTRTClient` for Neo and `SignalRRTClient` for Que
  - Register realtime callbacks and route parsed status events into `StateManager`
  - Best-effort realtime connection details discovery with Que fallback endpoint
- Add token synchronization to active realtime transport:
  - Sync token during normal request auth checks
  - Sync token after refresh-retry path in `_make_request()`
- Ensure API shutdown cleans up realtime transport (`close()` now calls `stop_push()`)
- Add extensive tests for new realtime integration behavior in `tests/test_actron.py`

## Validation
- `pytest --cov=src --cov-report=term-missing`
  - Result: **494 passed**, **100% total coverage**
- `pre-commit run --all-files --show-diff-on-failure`
  - Result: **all hooks passed**

## Notes
- No PR template file was present in the repository, so this PR description follows the project’s standard summary/changes/validation format.

Closes #77