### PR TITLE
Add Neo realtime details endpoint fallback and migrate to aiomqtt

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,7 @@ strict = True
 [mypy-aiohttp.*]
 ignore_missing_imports = True
 
-[mypy-asyncio_mqtt.*]
+[mypy-aiomqtt.*]
 ignore_missing_imports = True
 
 [mypy-setuptools.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp>=3.8.0",
-    "asyncio-mqtt>=0.16.2",
+    "aiomqtt>=1.0.0",
     "pydantic>=2.0.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp
-asyncio-mqtt
+aiomqtt
 mypy
 pydantic
 pytest

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -551,7 +551,7 @@ class ActronAirAPI:
                 serials[0]
             )
             if details is None:
-                _LOGGER.warning("Realtime connection details unavailable; push not started")
+                _LOGGER.info("Realtime connection details unavailable; push not started")
                 return False
 
             token = self.oauth2_auth.access_token
@@ -667,7 +667,12 @@ class ActronAirAPI:
         self,
         serial_number: str,
     ) -> RealtimeConnectionDetails | None:
-        """Discover realtime connection details from API links or platform defaults."""
+        """Discover realtime connection details from API links or platform defaults.
+
+        Neo systems may expose realtime details via a dedicated auth endpoint
+        without publishing HAL links on each system object. If link discovery
+        fails, we probe that endpoint before falling back.
+        """
         rel_candidates = (
             "rtc-details",
             "rtc",
@@ -685,6 +690,16 @@ class ActronAirAPI:
                         return details
                 except Exception:
                     _LOGGER.debug("Realtime details link %s lookup failed", rel, exc_info=True)
+
+        # Neo mobile clients request connection details directly from this endpoint.
+        if self.platform == PLATFORM_NEO:
+            try:
+                payload = await self._make_request("get", "messaging/connection/details")
+                details = self._parse_realtime_details_payload(payload)
+                if details is not None:
+                    return details
+            except Exception:
+                _LOGGER.debug("Realtime details endpoint lookup failed", exc_info=True)
 
         # Que fallback endpoint from documented SignalR path.
         if self.platform == PLATFORM_QUE:
@@ -708,15 +723,22 @@ class ActronAirAPI:
         elif isinstance(payload.get("rtcDetails"), dict):
             candidate = payload["rtcDetails"]
 
-        endpoint = self._pick_str(candidate, "endPoint", "endpoint", "host", "server")
-        user_id = self._pick_str(candidate, "userId", "user_id", "username") or "unknown"
+        endpoint = self._pick_str(
+            candidate,
+            "endPoint",
+            "endpoint",
+            "Endpoint",
+            "host",
+            "server",
+        )
+        user_id = self._pick_str(candidate, "userId", "UserId", "user_id", "username") or "unknown"
 
         if not endpoint:
             return None
 
-        raw_port = candidate.get("port")
+        raw_port = candidate.get("port", candidate.get("Port"))
         port = int(raw_port) if isinstance(raw_port, int | str) and str(raw_port).isdigit() else 443
-        protocol = self._pick_str(candidate, "protocol", "scheme") or "ssl"
+        protocol = self._pick_str(candidate, "protocol", "Protocol", "scheme") or "ssl"
 
         return RealtimeConnectionDetails(
             endpoint=endpoint,

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -736,7 +736,9 @@ class ActronAirAPI:
         if not endpoint:
             return None
 
-        raw_port = candidate.get("port", candidate.get("Port"))
+        raw_port = candidate.get("port")
+        if raw_port in (None, ""):
+            raw_port = candidate.get("Port")
         port = int(raw_port) if isinstance(raw_port, int | str) and str(raw_port).isdigit() else 443
         protocol = self._pick_str(candidate, "protocol", "Protocol", "scheme") or "ssl"
 

--- a/src/actron_neo_api/rt/mqtt_client.py
+++ b/src/actron_neo_api/rt/mqtt_client.py
@@ -17,7 +17,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-from asyncio_mqtt import Client, MqttError
+from aiomqtt import Client, MqttError
 
 from ..models import ActronAirStatus
 from .base import (
@@ -315,7 +315,7 @@ class MQTTRTClient:
         await self._set_state(RealtimeConnectionState.DISCONNECTED)
 
     def _build_client(self) -> Client:
-        """Create a configured asyncio-mqtt client instance."""
+        """Create a configured aiomqtt client instance."""
         tls_context = self._ssl_context
         if tls_context is None and self._details.uses_tls:
             tls_context = ssl.create_default_context()

--- a/src/actron_neo_api/rt/mqtt_client.py
+++ b/src/actron_neo_api/rt/mqtt_client.py
@@ -185,19 +185,13 @@ class MQTTRTClient:
         self._running = False
         self._connected_event.clear()
 
-        if self._client is not None:
-            try:
-                await self._client.disconnect()
-            except Exception:  # pragma: no cover - best effort cleanup
-                _LOGGER.debug("MQTT disconnect failed", exc_info=True)
-            finally:
-                self._client = None
-
         if self._supervisor_task is not None:
             self._supervisor_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._supervisor_task
             self._supervisor_task = None
+
+        self._client = None
 
         await self._set_state(RealtimeConnectionState.DISCONNECTED)
 
@@ -261,8 +255,9 @@ class MQTTRTClient:
             raise ValueError("access_token cannot be empty")
 
         self._access_token = access_token
-        if self._running and self._client is not None:
-            await self._client.disconnect()
+        if self._running:
+            await self.disconnect()
+            await self.connect()
 
     async def iter_events(self) -> AsyncIterator[RealtimeEvent]:
         """Yield realtime events as they arrive."""
@@ -286,11 +281,10 @@ class MQTTRTClient:
                     self._connected_event.set()
                     retry_delay = self._reconnect_initial_delay
 
-                    async with client.unfiltered_messages() as messages:
-                        async for message in messages:
-                            if not self._running:
-                                break
-                            await self._handle_message(str(message.topic), bytes(message.payload))
+                    async for message in client.messages:
+                        if not self._running:
+                            break
+                        await self._handle_message(str(message.topic), bytes(message.payload))
 
                 if self._running:
                     self._connected_event.clear()

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -1,6 +1,7 @@
 """Tests for ActronAirAPI core client functionality."""
 
 import asyncio
+import logging
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -1175,7 +1176,10 @@ class TestActronAirAPIRealtimeIntegration:
         assert started is True
 
     @pytest.mark.asyncio
-    async def test_start_push_returns_false_when_details_unavailable(self) -> None:
+    async def test_start_push_returns_false_when_details_unavailable(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """start_push should fallback when realtime details cannot be resolved."""
         api = ActronAirAPI(platform="neo")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
@@ -1187,9 +1191,12 @@ class TestActronAirAPIRealtimeIntegration:
 
         api._discover_realtime_connection_details = _discover  # type: ignore[method-assign]
 
-        started = await api.start_push()
+        with caplog.at_level(logging.INFO, logger="actron_neo_api.actron"):
+            started = await api.start_push()
 
         assert started is False
+        assert "Realtime connection details unavailable; push not started" in caplog.text
+        assert "WARNING" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_start_push_uses_explicit_serial_numbers(self) -> None:
@@ -1530,15 +1537,58 @@ class TestActronAirAPIRealtimeIntegration:
         assert parsed.protocol == "tcp"
         assert parsed.user_id == "u"
 
+        parsed_upper = api._parse_realtime_details_payload(
+            {
+                "Endpoint": "broker.upper.test",
+                "Port": 8883,
+                "Protocol": "ssl",
+                "UserId": "upper-user",
+            }
+        )
+        assert parsed_upper is not None
+        assert parsed_upper.endpoint == "broker.upper.test"
+        assert parsed_upper.port == 8883
+        assert parsed_upper.protocol == "ssl"
+        assert parsed_upper.user_id == "upper-user"
+
         assert api._parse_realtime_details_payload({"RTCDetails": {"port": "bad"}}) is None
         assert api._pick_str({"a": "", "b": " value "}, "a", "b") == "value"
         assert api._pick_str({"a": ""}, "a") is None
 
     @pytest.mark.asyncio
-    async def test_discover_realtime_details_returns_none_for_neo_without_links(self) -> None:
-        """Neo discovery should return None if no links/details are available."""
+    async def test_discover_realtime_details_uses_direct_endpoint_for_neo(self) -> None:
+        """Neo discovery should fall back to direct messaging endpoint when links are absent."""
         api = ActronAirAPI(platform="neo")
         api._get_system_link = lambda *_: None  # type: ignore[method-assign]
+
+        async def _req(method: str, endpoint: str) -> dict[str, Any]:
+            assert method == "get"
+            assert endpoint == "messaging/connection/details"
+            return {
+                "Endpoint": "broker.direct.test",
+                "Port": 8883,
+                "Protocol": "ssl",
+                "UserId": "u-direct",
+            }
+
+        api._make_request = _req  # type: ignore[method-assign]
+
+        details = await api._discover_realtime_connection_details("abc123")
+
+        assert details is not None
+        assert details.endpoint == "broker.direct.test"
+        assert details.user_id == "u-direct"
+
+    @pytest.mark.asyncio
+    async def test_discover_realtime_details_returns_none_for_neo_without_links(self) -> None:
+        """Neo discovery should return None if links and direct endpoint are unavailable."""
+        api = ActronAirAPI(platform="neo")
+        api._get_system_link = lambda *_: None  # type: ignore[method-assign]
+
+        async def _req(_: str, __: str) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        api._make_request = _req  # type: ignore[method-assign]
 
         details = await api._discover_realtime_connection_details("abc123")
 

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -1196,7 +1196,10 @@ class TestActronAirAPIRealtimeIntegration:
 
         assert started is False
         assert "Realtime connection details unavailable; push not started" in caplog.text
-        assert "WARNING" not in caplog.text
+        assert not any(
+            record.name == "actron_neo_api.actron" and record.levelno >= logging.WARNING
+            for record in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_start_push_uses_explicit_serial_numbers(self) -> None:
@@ -1550,6 +1553,18 @@ class TestActronAirAPIRealtimeIntegration:
         assert parsed_upper.port == 8883
         assert parsed_upper.protocol == "ssl"
         assert parsed_upper.user_id == "upper-user"
+
+        parsed_port_fallback = api._parse_realtime_details_payload(
+            {
+                "endpoint": "broker.fallback.test",
+                "port": None,
+                "Port": 1883,
+                "protocol": "tcp",
+                "userId": "fallback-user",
+            }
+        )
+        assert parsed_port_fallback is not None
+        assert parsed_port_fallback.port == 1883
 
         assert api._parse_realtime_details_payload({"RTCDetails": {"port": "bad"}}) is None
         assert api._pick_str({"a": "", "b": " value "}, "a", "b") == "value"

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -31,16 +31,10 @@ class _FakeMQTTMessage:
 
 
 class _FakeMQTTMessageStream:
-    """Async context manager/iterator yielding fake MQTT messages."""
+    """Async iterator yielding fake MQTT messages."""
 
     def __init__(self, messages: list[_FakeMQTTMessage]) -> None:
         self._messages = list(messages)
-
-    async def __aenter__(self) -> _FakeMQTTMessageStream:
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb) -> bool:
-        return False
 
     def __aiter__(self) -> _FakeMQTTMessageStream:
         return self
@@ -55,7 +49,7 @@ class _FakeMQTTClient:
     """Async context manager that mimics the MQTT client API used by the tests."""
 
     def __init__(self, messages: list[_FakeMQTTMessage] | None = None) -> None:
-        self.messages = messages or []
+        self._messages = messages or []
         self.subscriptions: list[str] = []
         self.unsubscriptions: list[str] = []
         self.published: list[tuple[str, bytes]] = []
@@ -67,8 +61,9 @@ class _FakeMQTTClient:
     async def __aexit__(self, exc_type, exc, tb) -> bool:
         return False
 
-    def unfiltered_messages(self) -> _FakeMQTTMessageStream:
-        return _FakeMQTTMessageStream(self.messages)
+    @property
+    def messages(self) -> _FakeMQTTMessageStream:
+        return _FakeMQTTMessageStream(self._messages)
 
     async def subscribe(self, topic: str) -> None:
         self.subscriptions.append(topic)
@@ -410,7 +405,7 @@ class TestMQTTRTClient:
 
     @pytest.mark.asyncio
     async def test_disconnect_with_live_client(self) -> None:
-        """Disconnect should close a live MQTT client and clear state."""
+        """Disconnect should clear local connection state."""
         client = MQTTRTClient(
             RealtimeConnectionDetails(
                 endpoint="mqtt.example.com",
@@ -426,7 +421,7 @@ class TestMQTTRTClient:
 
         await client.disconnect()
 
-        assert fake_client.disconnected is True
+        assert client._client is None  # noqa: SLF001 - internal lifecycle cleanup
         assert client.connection_state == RealtimeConnectionState.DISCONNECTED
 
     @pytest.mark.asyncio
@@ -663,7 +658,8 @@ class TestMQTTRTClient:
         )
 
         class _CleanClient(_FakeMQTTClient):
-            def unfiltered_messages(self) -> _FakeMQTTMessageStream:
+            @property
+            def messages(self) -> _FakeMQTTMessageStream:
                 return _FakeMQTTMessageStream([])
 
         states: list[RealtimeConnectionState] = []
@@ -788,8 +784,8 @@ class TestMQTTRTClient:
         client._client.publish.assert_awaited_once_with("actron/topic", b'{"b":2,"a":1}')
 
     @pytest.mark.asyncio
-    async def test_update_access_token_disconnects_running_client(self) -> None:
-        """Updating credentials should force the live client to disconnect."""
+    async def test_update_access_token_restarts_running_client(self) -> None:
+        """Updating credentials should restart the live client."""
         client = MQTTRTClient(
             RealtimeConnectionDetails(
                 endpoint="mqtt.example.com",
@@ -799,11 +795,15 @@ class TestMQTTRTClient:
             ),
             access_token="token-123",
         )
+
+        disconnect_mock = AsyncMock(return_value=None)
+        connect_mock = AsyncMock(return_value=None)
+        client.disconnect = disconnect_mock  # type: ignore[method-assign]
+        client.connect = connect_mock  # type: ignore[method-assign]
         client._running = True  # noqa: SLF001 - simulate an active connection
-        client._client = MagicMock()  # noqa: SLF001 - inject a fake broker client
-        client._client.disconnect = AsyncMock(return_value=None)
 
         await client.update_access_token("token-456")
 
         assert client.access_token == "token-456"
-        client._client.disconnect.assert_awaited_once()
+        disconnect_mock.assert_awaited_once()
+        connect_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- migrate MQTT dependency from `asyncio-mqtt` to `aiomqtt` (imports and dependency metadata)
- add Neo realtime discovery fallback to call `GET messaging/connection/details` when system links do not provide RTC details
- expand realtime detail parsing to accept Android-style capitalized fields (`Endpoint`, `Port`, `Protocol`, `UserId`)
- keep graceful fallback behavior when realtime details still cannot be resolved
- update tests for new discovery and parsing behavior

## Validation
- `pytest --cov=src --cov-report=term-missing` (pass)
- `pre-commit run --all-files` (pass)
