### PR TITLE
ci: replace deprecated codecov test-results action with codecov-action v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,9 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:


### PR DESCRIPTION
## Summary
This updates CI to stop using the deprecated `codecov/test-results-action@v1`.

## Changes
- Replaced `codecov/test-results-action@v1` with `codecov/codecov-action@v5`
- Added `report_type: test_results` for the test results upload step
- Kept existing Codecov token usage unchanged

## Why
`codecov/test-results-action` is deprecated and now warns to migrate to `codecov-action@v5` with `report_type: test_results`.

## Validation
- `pytest --cov=src --cov-report=term-missing` (498 passed, 100% coverage)
- `pytest` (498 passed)
- `pre-commit run --all-files` (all hooks passed)

Closes #85