### PR TITLE
Handle numeric SoftwareVersion/Signal_of3 values in status parsing

### DIFF
--- a/src/actron_neo_api/models/system.py
+++ b/src/actron_neo_api/models/system.py
@@ -56,6 +56,14 @@ class ActronAirOutdoorUnit(BaseModel):
     amb_temp: float = Field(0.0, alias="AmbTemp")
     family: str = Field("", alias="Family")
 
+    @field_validator("software_version", mode="before")
+    @classmethod
+    def normalize_software_version(cls, value: Any) -> str:
+        """Normalize software version values that may arrive as numbers."""
+        if value is None:
+            return ""
+        return str(value)
+
 
 class ActronAirLiveAircon(BaseModel):
     """Live operational data for the air conditioning system.

--- a/src/actron_neo_api/models/zone.py
+++ b/src/actron_neo_api/models/zone.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ..const import (
     AC_MODE_AUTO,
@@ -38,6 +38,14 @@ class ActronAirZoneSensor(BaseModel):
     temperature: float = Field(0.0, alias="LiveTemp_oC")
     humidity: float = Field(0.0, alias="RelativeHumidity_pc")
     battery_level: float = Field(0.0, alias="RemainingBatteryCapacity_pc")
+
+    @field_validator("signal_strength", mode="before")
+    @classmethod
+    def normalize_signal_strength(cls, value: Any) -> str:
+        """Normalize Signal_of3 values that may arrive as numbers."""
+        if value is None:
+            return "NA"
+        return str(value)
 
 
 class ActronAirPeripheral(BaseModel):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -169,6 +169,11 @@ class TestOutdoorUnitAliasParsing:
         unit = ActronAirOutdoorUnit.model_validate({"SoftwareVersion": 0})
         assert unit.software_version == "0"
 
+    def test_software_version_handles_none_value(self) -> None:
+        """software_version normalizes explicit None payloads to empty string."""
+        unit = ActronAirOutdoorUnit.model_validate({"SoftwareVersion": None})
+        assert unit.software_version == ""
+
     def test_defaults_to_empty_when_missing(self) -> None:
         """Fields default to empty values when not in data."""
         unit = ActronAirOutdoorUnit.model_validate({})

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -164,6 +164,11 @@ class TestOutdoorUnitAliasParsing:
         unit = ActronAirOutdoorUnit.model_validate({"SoftwareVersion": "v3.5.1"})
         assert unit.software_version == "v3.5.1"
 
+    def test_software_version_coerces_integer_value(self) -> None:
+        """software_version accepts integer payloads and normalizes to string."""
+        unit = ActronAirOutdoorUnit.model_validate({"SoftwareVersion": 0})
+        assert unit.software_version == "0"
+
     def test_defaults_to_empty_when_missing(self) -> None:
         """Fields default to empty values when not in data."""
         unit = ActronAirOutdoorUnit.model_validate({})

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -615,6 +615,13 @@ class TestZoneSensorAliasParsing:
         )
         assert sensor.signal_strength == "3"
 
+    def test_signal_strength_coerces_integer_value(self) -> None:
+        """signal_strength accepts integer payloads and normalizes to string."""
+        sensor = ActronAirZoneSensor.model_validate(
+            {"Signal_of3": 3, "Connected": True, "NV_Kind": "Wireless"}
+        )
+        assert sensor.signal_strength == "3"
+
     def test_signal_strength_default_when_missing(self) -> None:
         """signal_strength defaults to 'NA' when not in data."""
         sensor = ActronAirZoneSensor.model_validate({})

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -622,6 +622,13 @@ class TestZoneSensorAliasParsing:
         )
         assert sensor.signal_strength == "3"
 
+    def test_signal_strength_handles_none_value(self) -> None:
+        """signal_strength normalizes explicit None payloads to default string."""
+        sensor = ActronAirZoneSensor.model_validate(
+            {"Signal_of3": None, "Connected": True, "NV_Kind": "Wireless"}
+        )
+        assert sensor.signal_strength == "NA"
+
     def test_signal_strength_default_when_missing(self) -> None:
         """signal_strength defaults to 'NA' when not in data."""
         sensor = ActronAirZoneSensor.model_validate({})


### PR DESCRIPTION
## Summary
- coerce `OutdoorUnit.SoftwareVersion` values to string during model validation
- coerce `Sensors.*.Signal_of3` values to string during model validation
- add regression tests for integer payload values in both models

## Why
Some live status payloads send numeric values (`0`, `3`) for fields modeled as strings, which caused Pydantic validation errors and skipped parsing of `AirconSystem` and `RemoteZoneInfo`.

## Validation
- `pytest tests/test_system.py tests/test_zone.py -q`
- `pytest --cov=src --cov-report=term -q`
- `pre-commit run --all-files`