### PR TITLE
Identify MQTT realtime connections by account email and fix SignalR issues

### DIFF
--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -558,13 +558,16 @@ class ActronAirAPI:
                 return False
 
             token = self.oauth2_auth.access_token
+            user_info = await self.oauth2_auth.get_user_info()
+            user_email = user_info.email if user_info else "unknown"
+
             if not token:
                 raise ActronAirAuthError("No OAuth access token available for realtime transport")
 
             if self.platform == PLATFORM_QUE:
                 rt_client = SignalRRTClient(details, token)
             else:
-                rt_client = MQTTRTClient(details, token)
+                rt_client = MQTTRTClient(details, user_email, token)
 
             if rt_client is None:
                 raise ActronAirAPIError("Failed to create realtime transport client")

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -575,9 +575,7 @@ class ActronAirAPI:
             if self.platform == PLATFORM_QUE:
                 rt_client = SignalRRTClient(details, token)
             else:
-                user_info = await self.oauth2_auth.get_user_info()
-                user_email = user_info.email.strip() if user_info else ""
-                rt_client = MQTTRTClient(details, user_email or "unknown", token)
+                rt_client = MQTTRTClient(details, await self._resolve_mqtt_username(), token)
 
             if rt_client is None:
                 raise ActronAirAPIError("Failed to create realtime transport client")
@@ -615,6 +613,21 @@ class ActronAirAPI:
             _LOGGER.exception("Unexpected error starting realtime push; falling back to polling")
             await self._cleanup_failed_push(rt_client)
             return False
+
+    async def _resolve_mqtt_username(self) -> str:
+        """Return the account email used to identify MQTT broker connections.
+
+        The username only makes a broker connection attributable to an account;
+        it is not used for authentication (the access token is the password).
+        A lookup failure must therefore never prevent push from starting, so
+        every error is swallowed in favour of an empty username.
+        """
+        try:
+            user_info = await self.oauth2_auth.get_user_info()
+        except Exception as err:
+            _LOGGER.debug("Could not resolve account email for MQTT username: %s", err)
+            return ""
+        return user_info.email.strip() if user_info else ""
 
     async def _cleanup_failed_push(
         self,

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -558,8 +558,6 @@ class ActronAirAPI:
                 return False
 
             token = self.oauth2_auth.access_token
-            user_info = await self.oauth2_auth.get_user_info()
-            user_email = user_info.email if user_info else "unknown"
 
             if not token:
                 raise ActronAirAuthError("No OAuth access token available for realtime transport")
@@ -567,7 +565,9 @@ class ActronAirAPI:
             if self.platform == PLATFORM_QUE:
                 rt_client = SignalRRTClient(details, token)
             else:
-                rt_client = MQTTRTClient(details, user_email, token)
+                user_info = await self.oauth2_auth.get_user_info()
+                user_email = user_info.email.strip() if user_info else ""
+                rt_client = MQTTRTClient(details, user_email or "unknown", token)
 
             if rt_client is None:
                 raise ActronAirAPIError("Failed to create realtime transport client")

--- a/src/actron_neo_api/rt/mqtt_client.py
+++ b/src/actron_neo_api/rt/mqtt_client.py
@@ -42,6 +42,8 @@ _MQTT_TOPIC_STATUS_CHANGE = "mwc/status-change"
 _MQTT_DEFAULT_KEEPALIVE = 60
 _MQTT_DEFAULT_RECONNECT_DELAY = 0.5
 _MQTT_MAX_RECONNECT_DELAY = 60.0
+_MQTT_CLIENT_ID_PREFIX = "HA_"
+_MQTT_UNKNOWN_USERNAME = "unknown"
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,9 +66,11 @@ class MQTTRTClient:
     Args:
         connection_details: Realtime connection information from the backend.
         user_email: Account email, sent as the MQTT username so connections
-            are identifiable on the broker.
+            are identifiable on the broker. Blank or whitespace-only values
+            fall back to "unknown".
         access_token: OAuth access token used as the MQTT password.
-        client_id: Optional MQTT client identifier.
+        client_id: Optional MQTT client identifier. Generated identifiers are
+            prefixed with "HA_" so Home Assistant connections are recognisable.
         ssl_context: Optional custom TLS context.
         keepalive: MQTT keepalive interval in seconds.
         connect_timeout: Time to wait for the first successful connection.
@@ -103,8 +107,10 @@ class MQTTRTClient:
 
         self._details = connection_details
         self._access_token = access_token
-        self._user_email = user_email
-        self._client_id = client_id or "HA_" + uuid.uuid4().hex
+        # The broker only uses the username to attribute a connection, so an
+        # unusable value is normalized rather than rejected.
+        self._user_email = user_email.strip() or _MQTT_UNKNOWN_USERNAME
+        self._client_id = client_id or f"{_MQTT_CLIENT_ID_PREFIX}{uuid.uuid4().hex}"
         self._ssl_context = ssl_context
         self._keepalive = keepalive
         self._connect_timeout = connect_timeout

--- a/src/actron_neo_api/rt/mqtt_client.py
+++ b/src/actron_neo_api/rt/mqtt_client.py
@@ -64,6 +64,8 @@ class MQTTRTClient:
 
     Args:
         connection_details: Realtime connection information from the backend.
+        user_email: Account email, sent as the MQTT username so connections
+            are identifiable on the broker.
         access_token: OAuth access token used as the MQTT password.
         client_id: Optional MQTT client identifier.
         ssl_context: Optional custom TLS context.
@@ -79,6 +81,7 @@ class MQTTRTClient:
     def __init__(
         self,
         connection_details: RealtimeConnectionDetails,
+        user_email: str,
         access_token: str,
         client_id: str | None = None,
         ssl_context: ssl.SSLContext | None = None,
@@ -101,7 +104,8 @@ class MQTTRTClient:
 
         self._details = connection_details
         self._access_token = access_token
-        self._client_id = client_id or uuid.uuid4().hex
+        self._user_email = user_email
+        self._client_id = client_id or "HA_" + uuid.uuid4().hex
         self._ssl_context = ssl_context
         self._keepalive = keepalive
         self._connect_timeout = connect_timeout
@@ -321,7 +325,7 @@ class MQTTRTClient:
         client_kwargs: dict[str, Any] = {
             "hostname": self._details.endpoint,
             "port": self._details.port,
-            "username": "",
+            "username": self._user_email,
             "password": self._access_token,
             "keepalive": self._keepalive,
             "clean_session": False,

--- a/src/actron_neo_api/rt/signalr_client.py
+++ b/src/actron_neo_api/rt/signalr_client.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 from typing import Any, AsyncIterator, Callable, Optional
+from urllib.parse import quote
 
 import aiohttp
 
@@ -277,8 +278,10 @@ class SignalRRTClient(RealtimeClient):
     async def _negotiate(self) -> str:
         """Call the SignalR negotiate endpoint and return an SSE connect URL.
 
-        The negotiate response varies; prefer an explicit `url` when present,
-        otherwise build a serverSentEvents URL using a connectionId/token.
+        The Actron cloud speaks classic ASP.NET SignalR (not SignalR Core):
+        negotiate responses use PascalCase fields, and the SSE transport is
+        reached via a `/connect` endpoint carrying the URL-encoded connection
+        token and client protocol version, not the bare hub URL.
         """
         session = self._session
         if session is None:
@@ -291,21 +294,20 @@ class SignalRRTClient(RealtimeClient):
                 raise RuntimeError(f"negotiate failed: {resp.status}")
             data = await resp.json()
 
-        # If server returned a connect URL, use it directly.
-        if isinstance(data, dict) and "url" in data:
-            return str(data["url"])
+        if not isinstance(data, dict):
+            return str(self._connection_details.endpoint)
 
-        # Otherwise try to construct a serverSentEvents URL.
-        connection_id = data.get("connectionId") if isinstance(data, dict) else None
-        token = data.get("connectionToken") if isinstance(data, dict) else None
+        token = data.get("ConnectionToken") or data.get("connectionToken")
+        if not token:
+            return str(self._connection_details.endpoint)
+
+        protocol = data.get("ProtocolVersion") or data.get("protocolVersion") or "1.2"
         base = self._connection_details.endpoint.rstrip("/")
-        if connection_id:
-            # SignalR-compatible query for serverSentEvents transport
-            return f"{base}/?id={connection_id}&transport=serverSentEvents"
-        if token:
-            return f"{base}/?transport=serverSentEvents&connectionToken={token}"
-        # Fallback to the base endpoint
-        return str(self._connection_details.endpoint)
+        return (
+            f"{base}/connect?transport=serverSentEvents"
+            f"&connectionToken={quote(token, safe='')}"
+            f"&clientProtocol={protocol}"
+        )
 
     async def _restore_subscriptions(self) -> None:
         """Resend subscribe commands for current subscriptions after reconnect."""

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -961,12 +961,27 @@ class TestActronAirAPIRealtimeIntegration:
     """Test issue #77 realtime public API integration."""
 
     @pytest.mark.asyncio
-    async def test_start_push_selects_mqtt_for_neo(self) -> None:
-        """Neo platform should use the MQTT transport."""
+    @pytest.mark.parametrize(
+        ("user_info", "expected_username"),
+        [
+            pytest.param(ActronAirUserInfo(email="user@example.test"), "user@example.test", id="normal"),
+            pytest.param(ActronAirUserInfo(email="  user@example.test  "), "user@example.test", id="whitespace"),
+            pytest.param(ActronAirUserInfo(email=""), "unknown", id="empty"),
+            pytest.param(ActronAirUserInfo(email="   "), "unknown", id="blank"),
+            pytest.param(None, "unknown", id="no_user_info"),
+        ],
+    )
+    async def test_start_push_selects_mqtt_for_neo(
+        self, user_info: ActronAirUserInfo | None, expected_username: str
+    ) -> None:
+        """Neo platform should use the MQTT transport with a normalized username."""
 
         class FakeMQTTClient:
-            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+            def __init__(
+                self, details: RealtimeConnectionDetails, user_email: str, token: str
+            ) -> None:
                 self.details = details
+                self.user_email = user_email
                 self.token = token
                 self.callbacks: list[Any] = []
                 self.subscribed: list[str] = []
@@ -989,6 +1004,7 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI(platform="neo")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
         api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(return_value=user_info)
         api.systems = [ActronAirSystemInfo(serial="ABC123")]
 
         async def _discover(_: str) -> RealtimeConnectionDetails:
@@ -1013,6 +1029,7 @@ class TestActronAirAPIRealtimeIntegration:
         assert started is True
         assert isinstance(api._rt_client, FakeMQTTClient)
         assert api._rt_client.subscribed == ["abc123"]
+        assert api._rt_client.user_email == expected_username
 
     @pytest.mark.asyncio
     async def test_start_push_selects_signalr_for_que(self) -> None:
@@ -1042,6 +1059,7 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI(platform="que")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
         api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(side_effect=AssertionError("should not be called"))
         api.systems = [ActronAirSystemInfo(serial="xyz789")]
 
         async def _discover(_: str) -> RealtimeConnectionDetails:
@@ -1483,7 +1501,9 @@ class TestActronAirAPIRealtimeIntegration:
         """start_push should honor provided serial_numbers and ignore blanks."""
 
         class FakeMQTTClient:
-            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+            def __init__(
+                self, details: RealtimeConnectionDetails, user_email: str, token: str
+            ) -> None:
                 self.subscribed: list[str] = []
 
             def register_callback(self, callback: Any) -> None:
@@ -1504,6 +1524,9 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI(platform="neo")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
         api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(
+            return_value=ActronAirUserInfo(email="user@example.test")
+        )
 
         details = RealtimeConnectionDetails(
             endpoint="mqtt.example.test",
@@ -1586,7 +1609,9 @@ class TestActronAirAPIRealtimeIntegration:
         class FakeMQTTClient:
             instances: list["FakeMQTTClient"] = []
 
-            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+            def __init__(
+                self, details: RealtimeConnectionDetails, user_email: str, token: str
+            ) -> None:
                 self.disconnect = AsyncMock(return_value=None)
                 FakeMQTTClient.instances.append(self)
 
@@ -1605,6 +1630,9 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI(platform="neo")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
         api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(
+            return_value=ActronAirUserInfo(email="user@example.test")
+        )
         api.systems = [ActronAirSystemInfo(serial="abc123")]
 
         details = RealtimeConnectionDetails(
@@ -1635,7 +1663,9 @@ class TestActronAirAPIRealtimeIntegration:
         """Registered transport callback should schedule event handling task."""
 
         class FakeMQTTClient:
-            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+            def __init__(
+                self, details: RealtimeConnectionDetails, user_email: str, token: str
+            ) -> None:
                 self.callback: Any = None
 
             def register_callback(self, callback: Any) -> None:
@@ -1666,6 +1696,9 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI(platform="neo")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
         api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(
+            return_value=ActronAirUserInfo(email="user@example.test")
+        )
         api.systems = [ActronAirSystemInfo(serial="abc123")]
 
         details = RealtimeConnectionDetails(

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -967,17 +967,27 @@ class TestActronAirAPIRealtimeIntegration:
     @pytest.mark.parametrize(
         ("user_info", "expected_username"),
         [
-            pytest.param(ActronAirUserInfo(email="user@example.test"), "user@example.test", id="normal"),
-            pytest.param(ActronAirUserInfo(email="  user@example.test  "), "user@example.test", id="whitespace"),
-            pytest.param(ActronAirUserInfo(email=""), "unknown", id="empty"),
-            pytest.param(ActronAirUserInfo(email="   "), "unknown", id="blank"),
-            pytest.param(None, "unknown", id="no_user_info"),
+            pytest.param(
+                ActronAirUserInfo(email="user@example.test"), "user@example.test", id="normal"
+            ),
+            pytest.param(
+                ActronAirUserInfo(email="  user@example.test  "),
+                "user@example.test",
+                id="whitespace",
+            ),
+            pytest.param(ActronAirUserInfo(email=""), "", id="empty"),
+            pytest.param(ActronAirUserInfo(email="   "), "", id="blank"),
+            pytest.param(None, "", id="no_user_info"),
         ],
     )
     async def test_start_push_selects_mqtt_for_neo(
         self, user_info: ActronAirUserInfo | None, expected_username: str
     ) -> None:
-        """Neo platform should use the MQTT transport with a normalized username."""
+        """Neo platform should use the MQTT transport with a normalized username.
+
+        An unusable email is passed through as an empty string; MQTTRTClient
+        owns the fallback to "unknown".
+        """
 
         class FakeMQTTClient:
             def __init__(
@@ -1035,6 +1045,65 @@ class TestActronAirAPIRealtimeIntegration:
         assert api._rt_client.user_email == expected_username
 
     @pytest.mark.asyncio
+    async def test_start_push_survives_user_info_failure(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A user-info lookup failure must not stop push or trigger reauth.
+
+        The email is only a broker-side label, so its lookup is best-effort even
+        though get_user_info() reports every failure as an auth error.
+        """
+
+        class FakeMQTTClient:
+            def __init__(
+                self, details: RealtimeConnectionDetails, user_email: str, token: str
+            ) -> None:
+                self.user_email = user_email
+
+            def register_callback(self, callback: Any) -> None:
+                self.callback = callback
+
+            async def connect(self) -> None:
+                return None
+
+            async def subscribe_system(self, serial: str) -> None:
+                return None
+
+            async def disconnect(self) -> None:
+                return None
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(
+            side_effect=ActronAirAuthError("user info unavailable")
+        )
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test",
+            port=8883,
+            protocol="ssl",
+            user_id="u",
+        )
+
+        from actron_neo_api import actron as actron_module
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = FakeMQTTClient  # type: ignore[assignment]
+            with caplog.at_level(logging.DEBUG, logger="actron_neo_api.actron"):
+                started = await api.start_push(connection_details=details)
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert started is True
+        assert isinstance(api._rt_client, FakeMQTTClient)
+        assert api._rt_client.user_email == ""
+        assert "Could not resolve account email for MQTT username" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_start_push_selects_signalr_for_que(self) -> None:
         """Que platform should use the SignalR transport."""
 
@@ -1062,7 +1131,9 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI(platform="que")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
         api.oauth2_auth.access_token = "token"
-        api.oauth2_auth.get_user_info = AsyncMock(side_effect=AssertionError("should not be called"))
+        api.oauth2_auth.get_user_info = AsyncMock(
+            side_effect=AssertionError("should not be called")
+        )
         api.systems = [ActronAirSystemInfo(serial="xyz789")]
 
         async def _discover(_: str) -> RealtimeConnectionDetails:
@@ -1669,7 +1740,9 @@ class TestActronAirAPIRealtimeIntegration:
         """A broker failure is an expected fallback: debug level, no traceback."""
 
         class FakeMQTTClient:
-            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+            def __init__(
+                self, details: RealtimeConnectionDetails, user_email: str, token: str
+            ) -> None:
                 self.disconnect = AsyncMock(return_value=None)
 
             def register_callback(self, callback: Any) -> None:
@@ -1684,6 +1757,9 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI(platform="neo")
         api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
         api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(
+            return_value=ActronAirUserInfo(email="user@example.test")
+        )
         api.systems = [ActronAirSystemInfo(serial="abc123")]
 
         details = RealtimeConnectionDetails(

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -144,7 +144,7 @@ class TestMQTTRTClient:
             protocol="ssl",
             user_id="user-1",
         )
-        client = MQTTRTClient(details, access_token="token-123")
+        client = MQTTRTClient(details, user_email="test@example.com", access_token="token-123")
 
         assert client.connection_details is details
         assert client.access_token == "token-123"
@@ -193,6 +193,7 @@ class TestMQTTRTClient:
                     protocol="ssl",
                     user_id="user-1",
                 ),
+                user_email="test@example.com",
                 access_token=access_token,
                 keepalive=keepalive,
                 connect_timeout=connect_timeout,
@@ -235,6 +236,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -263,6 +265,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         sentinel = object()
@@ -293,6 +296,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -325,6 +329,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         seen: list[tuple[str, str]] = []
@@ -364,6 +369,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -391,6 +397,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -431,6 +438,7 @@ class TestMQTTRTClient:
                 protocol="tls",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -455,6 +463,7 @@ class TestMQTTRTClient:
                 protocol="tls",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         host_client = MQTTRTClient(
@@ -464,6 +473,7 @@ class TestMQTTRTClient:
                 protocol="tls",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -482,6 +492,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -524,6 +535,7 @@ class TestMQTTRTClient:
                 protocol="tcp",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -545,6 +557,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         client._supervisor_task = asyncio.create_task(asyncio.sleep(0.1))  # noqa: SLF001
@@ -566,6 +579,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -594,6 +608,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         fake_client = _FakeMQTTClient()
@@ -615,6 +630,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         fake_client = _FakeMQTTClient()
@@ -642,6 +658,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -667,6 +684,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         fake_client = _FakeMQTTClient()
@@ -694,6 +712,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -711,6 +730,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -729,6 +749,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         client._ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)  # noqa: SLF001
@@ -810,6 +831,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         event = RealtimeConnectionEvent(
@@ -841,6 +863,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -882,6 +905,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -919,6 +943,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -946,6 +971,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         monkeypatch.setattr(
@@ -970,6 +996,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -1001,6 +1028,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
         client._client = MagicMock()  # noqa: SLF001 - inject a fake broker client
@@ -1021,6 +1049,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -1046,6 +1075,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 
@@ -1073,6 +1103,7 @@ class TestMQTTRTClient:
                 protocol="ssl",
                 user_id="user-1",
             ),
+            user_email="test@example.com",
             access_token="token-123",
         )
 

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -152,6 +152,47 @@ class TestMQTTRTClient:
         assert client.last_error is None
 
     @pytest.mark.parametrize(
+        ("user_email", "expected"),
+        [
+            ("test@example.com", "test@example.com"),
+            ("  test@example.com  ", "test@example.com"),
+            ("", "unknown"),
+            ("   ", "unknown"),
+        ],
+    )
+    def test_username_is_normalized(self, user_email: str, expected: str) -> None:
+        """A blank username would defeat the point of identifying connections."""
+        client = MQTTRTClient(
+            RealtimeConnectionDetails(
+                endpoint="mqtt.example.com",
+                port=8883,
+                protocol="ssl",
+                user_id="user-1",
+            ),
+            user_email=user_email,
+            access_token="token-123",
+        )
+
+        assert client._user_email == expected  # noqa: SLF001 - broker username regression check
+
+    def test_generated_client_id_is_prefixed(self) -> None:
+        """Generated identifiers should be recognisable as Home Assistant clients."""
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.com",
+            port=8883,
+            protocol="ssl",
+            user_id="user-1",
+        )
+
+        generated = MQTTRTClient(details, user_email="a@b.test", access_token="token-123")
+        explicit = MQTTRTClient(
+            details, user_email="a@b.test", access_token="token-123", client_id="my-client"
+        )
+
+        assert generated._client_id.startswith("HA_")  # noqa: SLF001 - broker identity check
+        assert explicit._client_id == "my-client"  # noqa: SLF001 - explicit id wins
+
+    @pytest.mark.parametrize(
         (
             "access_token",
             "keepalive",

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -574,9 +574,10 @@ def test_constructor_validation(
             id="url_encodes_special_characters",
         ),
         pytest.param({"other": "value"}, "https://example.test/signalr", id="no_token"),
+        pytest.param(["unexpected"], "https://example.test/signalr", id="non_dict_response"),
     ],
 )
-async def test_negotiate_url_variants(payload: dict[str, str], expected: str) -> None:
+async def test_negotiate_url_variants(payload: Any, expected: str) -> None:
     session = _Session(post_responses=[_Response(status=200, json_data=payload)])
     client = SignalRRTClient(_details(), access_token="secret", session=session)
 

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -549,16 +549,31 @@ def test_constructor_validation(
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
-        ({"url": "https://example.test/signalr/sse"}, "https://example.test/signalr/sse"),
-        (
-            {"connectionId": "cid-1"},
-            "https://example.test/signalr/?id=cid-1&transport=serverSentEvents",
+        pytest.param(
+            {"ConnectionToken": "tok-1", "ProtocolVersion": "1.2"},
+            "https://example.test/signalr/connect?transport=serverSentEvents"
+            "&connectionToken=tok-1&clientProtocol=1.2",
+            id="pascal_case",
         ),
-        (
-            {"connectionToken": "tok-1"},
-            "https://example.test/signalr/?transport=serverSentEvents&connectionToken=tok-1",
+        pytest.param(
+            {"connectionToken": "tok-2", "protocolVersion": "1.5"},
+            "https://example.test/signalr/connect?transport=serverSentEvents"
+            "&connectionToken=tok-2&clientProtocol=1.5",
+            id="camel_case",
         ),
-        ({"other": "value"}, "https://example.test/signalr"),
+        pytest.param(
+            {"ConnectionToken": "tok-3"},
+            "https://example.test/signalr/connect?transport=serverSentEvents"
+            "&connectionToken=tok-3&clientProtocol=1.2",
+            id="default_protocol_version",
+        ),
+        pytest.param(
+            {"ConnectionToken": "a/b+c=="},
+            "https://example.test/signalr/connect?transport=serverSentEvents"
+            "&connectionToken=a%2Fb%2Bc%3D%3D&clientProtocol=1.2",
+            id="url_encodes_special_characters",
+        ),
+        pytest.param({"other": "value"}, "https://example.test/signalr", id="no_token"),
     ],
 )
 async def test_negotiate_url_variants(payload: dict[str, str], expected: str) -> None:


### PR DESCRIPTION
Neo MQTT push connections currently authenticate with a blank username and a bare random client_id, making it impossible to tell which integration or account a given broker connection belongs to.

Send the account email as the MQTT username and prefix the generated client_id with "HA_" so Home Assistant-originated connections are identifiable on the broker.