### PR TITLE
Align realtime API with Home Assistant idioms

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Realtime transport selection is automatic when push is enabled:
 - **Neo** systems use the MQTT realtime transport.
 - **Que (NX-Gen)** systems use the SignalR (SSE) realtime transport.
 - If realtime startup fails, `start_push()` returns `False` and your existing polling flow remains available.
+- If the credentials are rejected, `start_push()` raises `ActronAirAuthError` instead, so callers can trigger re-authentication rather than silently falling back to polling.
 
 ---
 
@@ -91,12 +92,19 @@ async def main() -> None:
     def on_update(status):
         print(f"Push update for {status.serial_number}")
 
-    api.subscribe_system_updates(serial, on_update)
+    def on_connection(event):
+        print(f"Realtime transport is now {event.state.value}")
+
+    # Both subscribe calls return a callable that removes the subscription.
+    unsubscribe = api.subscribe_system_updates(serial, on_update)
+    unsubscribe_connection = api.subscribe_connection_state(on_connection)
 
     async for status in api.stream_system_updates(serial):
         print(f"Mode: {status.user_aircon_settings.mode}")
         break
 
+    unsubscribe()
+    unsubscribe_connection()
     await api.stop_push()
 
 

--- a/docs/rt_push_implementation.md
+++ b/docs/rt_push_implementation.md
@@ -6,7 +6,7 @@ Realtime push support is now available in the library for both supported Actron 
 
 - Neo systems use the MQTT realtime transport.
 - Que (NX-Gen) systems use the SignalR/SSE realtime transport.
-- The public API exposes `start_push()`, `stop_push()`, `subscribe_system_updates()`, and `stream_system_updates()`.
+- The public API exposes `start_push()`, `stop_push()`, `subscribe_system_updates()`, `subscribe_connection_state()`, and `stream_system_updates()`.
 - Realtime updates are converted into the same `ActronAirStatus` model used by the polling API.
 
 This means consumer code can work with one status model regardless of whether updates arrive through polling or push.
@@ -18,7 +18,8 @@ This means consumer code can work with one status model regardless of whether up
 3. Call `start_push()` for one or more serial numbers.
 4. If `start_push()` returns `True`, consume updates with either callbacks or the async stream API.
 5. If `start_push()` returns `False`, continue using your normal polling flow.
-6. Call `stop_push()` when you no longer want realtime updates.
+6. If `start_push()` raises `ActronAirAuthError`, re-authenticate; polling would fail the same way.
+7. Call `stop_push()` when you no longer want realtime updates.
 
 ## Example
 
@@ -41,16 +42,39 @@ async def main() -> None:
     def on_update(status) -> None:
         print(f"Update received for {status.serial_number}")
 
-    api.subscribe_system_updates(serial, on_update)
+    unsubscribe = api.subscribe_system_updates(serial, on_update)
 
     async for status in api.stream_system_updates(serial):
         print(status.user_aircon_settings.mode)
         break
 
+    unsubscribe()
     await api.stop_push()
 
 
 asyncio.run(main())
+```
+
+## Subscriptions
+
+`subscribe_system_updates()` and `subscribe_connection_state()` both return a
+zero-argument callable that removes the subscription. Calling it more than once
+is safe, which matches the remove-listener idiom used by Home Assistant
+(`CALLBACK_TYPE`).
+
+`subscribe_connection_state()` reports transport connection transitions as
+`RealtimeConnectionEvent` values (`connecting`, `connected`, `reconnecting`,
+`disconnected`, `error`). Connection state belongs to the transport rather than
+to a single system, so one callback covers every subscribed serial. Callbacks
+may be sync or async, and an exception raised inside one is logged without
+disrupting the transport.
+
+```python
+def on_connection(event) -> None:
+    print(event.state.value, event.previous_state, event.reason)
+
+
+unsubscribe_connection = api.subscribe_connection_state(on_connection)
 ```
 
 ## Platform Behavior
@@ -66,6 +90,8 @@ Push is optional.
 
 - If `start_push()` succeeds, updates can be consumed through callbacks or `stream_system_updates()`.
 - If `start_push()` returns `False`, push was not started and the caller should continue using polling.
+- Expected failures (broker unreachable, connection details missing, network errors) are logged at debug level, since falling back to polling is normal operation.
+- Authentication failures are not treated as a fallback: `start_push()` re-raises `ActronAirAuthError` so the caller can start a reauth flow.
 - The library does not automatically begin polling when push startup fails.
 
 ## Home Assistant Impact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp>=3.8.0",
-    "aiomqtt>=1.0.0",
+    "aiomqtt>=2.0.0",
     "pydantic>=2.0.0",
 ]
 

--- a/realtime_example.py
+++ b/realtime_example.py
@@ -286,6 +286,9 @@ async def main() -> None:
 
         callback: Callable[[ActronAirStatus], Awaitable[None] | None] = _print_callback
         api.subscribe_system_updates(serial, callback)
+        api.subscribe_connection_state(
+            lambda event: print(f"connection state: {event.state.value}")
+        )
         if debug_raw and isinstance(api._rt_client, MQTTRTClient):  # noqa: SLF001 - targeted smoke-test debug hook
             api._rt_client.register_callback(_print_raw_event)
             print("Raw realtime event debugging is enabled.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp
-aiomqtt
+aiomqtt>=2.0.0
 mypy
 pydantic
 pytest

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from typing import Any, Literal
 
 import aiohttp
+from aiomqtt import MqttError
 
 from .const import (
     BASE_URL_DEFAULT,
@@ -35,6 +36,7 @@ from .oauth import ActronAirOAuth2DeviceCodeAuth
 from .rt import (
     MQTTRTClient,
     RealtimeConnectionDetails,
+    RealtimeConnectionEvent,
     RealtimeEvent,
     RealtimeMessage,
     SignalRRTClient,
@@ -335,6 +337,9 @@ class ActronAirAPI:
         self._push_callbacks: dict[
             str, list[Callable[[ActronAirStatus], Awaitable[None] | None]]
         ] = {}
+        self._push_connection_callbacks: list[
+            Callable[[RealtimeConnectionEvent], Awaitable[None] | None]
+        ] = []
         self._refresh_tasks_lock = asyncio.Lock()
         self._refresh_status_tasks: dict[str, asyncio.Task[ActronAirStatus | None]] = {}
 
@@ -528,7 +533,12 @@ class ActronAirAPI:
                 If omitted, the client attempts to discover details from API links.
 
         Returns:
-            True if realtime push started successfully, otherwise False.
+            True if realtime push started successfully, False if realtime is
+            unavailable and the caller should fall back to polling.
+
+        Raises:
+            ActronAirAuthError: If the credentials are no longer valid. Callers
+                should re-authenticate rather than fall back to polling.
         """
         if self._rt_client is not None and self._push_running:
             return True
@@ -554,7 +564,7 @@ class ActronAirAPI:
                 serials[0]
             )
             if details is None:
-                _LOGGER.info("Realtime connection details unavailable; push not started")
+                _LOGGER.debug("Realtime connection details unavailable; push not started")
                 return False
 
             token = self.oauth2_auth.access_token
@@ -585,17 +595,37 @@ class ActronAirAPI:
             self._rt_client = rt_client
             self._push_running = True
             return True
-        except Exception:
-            _LOGGER.exception("Failed to start realtime push; falling back to polling")
-            cleanup_client = self._rt_client or rt_client
-            if cleanup_client is not None:
-                try:
-                    await cleanup_client.disconnect()
-                except Exception:
-                    _LOGGER.debug("Failed to clean up realtime client", exc_info=True)
-            self._rt_client = None
-            self._push_running = False
+        except ActronAirAuthError:
+            # Credentials are no longer usable; polling would fail the same way.
+            await self._cleanup_failed_push(rt_client)
+            raise
+        except (
+            ActronAirAPIError,
+            MqttError,
+            aiohttp.ClientError,
+            OSError,  # covers TimeoutError, ConnectionError and ssl.SSLError
+        ) as err:
+            _LOGGER.debug("Realtime push unavailable (%s); falling back to polling", err)
+            await self._cleanup_failed_push(rt_client)
             return False
+        except Exception:
+            _LOGGER.exception("Unexpected error starting realtime push; falling back to polling")
+            await self._cleanup_failed_push(rt_client)
+            return False
+
+    async def _cleanup_failed_push(
+        self,
+        rt_client: MQTTRTClient | SignalRRTClient | None,
+    ) -> None:
+        """Disconnect a partially started transport and reset push state."""
+        cleanup_client = self._rt_client or rt_client
+        if cleanup_client is not None:
+            try:
+                await cleanup_client.disconnect()
+            except Exception:
+                _LOGGER.debug("Failed to clean up realtime client", exc_info=True)
+        self._rt_client = None
+        self._push_running = False
 
     async def stop_push(self) -> None:
         """Stop realtime push updates and disconnect active transport."""
@@ -615,12 +645,16 @@ class ActronAirAPI:
         self,
         serial_number: str,
         callback: Callable[[ActronAirStatus], Awaitable[None] | None],
-    ) -> None:
+    ) -> Callable[[], None]:
         """Register a callback for status updates of a specific system.
 
         Args:
             serial_number: Target system serial number.
             callback: Callback invoked with each parsed status update.
+
+        Returns:
+            A callable that removes this subscription. Calling it more than
+            once is safe.
 
         Raises:
             ValueError: If serial_number is empty.
@@ -629,6 +663,48 @@ class ActronAirAPI:
         if not serial:
             raise ValueError("serial_number cannot be empty")
         self._push_callbacks.setdefault(serial, []).append(callback)
+
+        def _remove_subscription() -> None:
+            """Remove this callback registration."""
+            callbacks = self._push_callbacks.get(serial)
+            if callbacks is None:
+                return
+            try:
+                callbacks.remove(callback)
+            except ValueError:
+                return
+            if not callbacks:
+                self._push_callbacks.pop(serial, None)
+
+        return _remove_subscription
+
+    def subscribe_connection_state(
+        self,
+        callback: Callable[[RealtimeConnectionEvent], Awaitable[None] | None],
+    ) -> Callable[[], None]:
+        """Register a callback for realtime transport connection changes.
+
+        Connection state belongs to the transport rather than to a single
+        system, so a callback registered here receives every transition for
+        as long as push is running.
+
+        Args:
+            callback: Callback invoked with each connection state transition.
+
+        Returns:
+            A callable that removes this subscription. Calling it more than
+            once is safe.
+        """
+        self._push_connection_callbacks.append(callback)
+
+        def _remove_subscription() -> None:
+            """Remove this callback registration."""
+            try:
+                self._push_connection_callbacks.remove(callback)
+            except ValueError:
+                return
+
+        return _remove_subscription
 
     async def stream_system_updates(
         self,
@@ -769,6 +845,10 @@ class ActronAirAPI:
 
     async def _handle_realtime_event(self, event: RealtimeEvent) -> None:
         """Process an incoming realtime event from active transport."""
+        if isinstance(event, RealtimeConnectionEvent):
+            await self._dispatch_connection_event(event)
+            return
+
         if not isinstance(event, RealtimeMessage):
             return
 
@@ -795,6 +875,21 @@ class ActronAirAPI:
                 _LOGGER.warning(
                     "Realtime callback failed for %s: %s",
                     serial,
+                    err,
+                    exc_info=True,
+                )
+
+    async def _dispatch_connection_event(self, event: RealtimeConnectionEvent) -> None:
+        """Notify connection-state subscribers of a transport transition."""
+        for callback in list(self._push_connection_callbacks):
+            try:
+                result = callback(event)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as err:
+                _LOGGER.warning(
+                    "Realtime connection callback failed for %s: %s",
+                    event.state.value,
                     err,
                     exc_info=True,
                 )

--- a/src/actron_neo_api/rt/mqtt_client.py
+++ b/src/actron_neo_api/rt/mqtt_client.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import inspect
 import ipaddress
 import json
 import logging
@@ -325,9 +324,8 @@ class MQTTRTClient:
             "password": self._access_token,
             "keepalive": self._keepalive,
             "clean_session": False,
+            "identifier": self._client_id,
         }
-        client_identifier_arg = self._get_client_identifier_arg_name()
-        client_kwargs[client_identifier_arg] = self._client_id
         if tls_context is not None:
             client_kwargs["tls_context"] = tls_context
 
@@ -351,18 +349,6 @@ class MQTTRTClient:
         except ValueError:
             return False
         return True
-
-    @staticmethod
-    def _get_client_identifier_arg_name() -> str:
-        """Return the supported aiomqtt identifier keyword for the current version."""
-        try:
-            client_signature = inspect.signature(Client)
-        except (TypeError, ValueError):
-            return "identifier"
-
-        if "identifier" in client_signature.parameters:
-            return "identifier"
-        return "client_id"
 
     async def _restore_subscriptions(self, client: Client) -> None:
         """Resubscribe to all known topics after a reconnect."""

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiomqtt import MqttError
 
 from actron_neo_api import ActronAirAPI
 from actron_neo_api.exceptions import ActronAirAPIError, ActronAirAuthError
@@ -20,6 +21,8 @@ from actron_neo_api.models import (
 from actron_neo_api.models.system import ActronAirSystemInfo
 from actron_neo_api.rt.base import (
     RealtimeConnectionDetails,
+    RealtimeConnectionEvent,
+    RealtimeConnectionState,
     RealtimeEvent,
     RealtimeEventKind,
     RealtimeMessage,
@@ -1468,13 +1471,14 @@ class TestActronAirAPIRealtimeIntegration:
 
         api._discover_realtime_connection_details = _discover  # type: ignore[method-assign]
 
-        with caplog.at_level(logging.INFO, logger="actron_neo_api.actron"):
+        with caplog.at_level(logging.DEBUG, logger="actron_neo_api.actron"):
             started = await api.start_push()
 
         assert started is False
         assert "Realtime connection details unavailable; push not started" in caplog.text
+        # Unavailable realtime is an expected fallback, not an operator-facing problem.
         assert not any(
-            record.name == "actron_neo_api.actron" and record.levelno >= logging.WARNING
+            record.name == "actron_neo_api.actron" and record.levelno > logging.DEBUG
             for record in caplog.records
         )
 
@@ -1555,8 +1559,8 @@ class TestActronAirAPIRealtimeIntegration:
         assert api._rt_client is None
 
     @pytest.mark.asyncio
-    async def test_start_push_handles_missing_token_and_cleanup_error(self) -> None:
-        """start_push should handle auth failure and cleanup failures gracefully."""
+    async def test_start_push_raises_auth_error_and_survives_cleanup_error(self) -> None:
+        """start_push should re-raise auth failures after tolerating cleanup errors."""
 
         class _OldClient:
             async def disconnect(self) -> None:
@@ -1574,10 +1578,11 @@ class TestActronAirAPIRealtimeIntegration:
             protocol="ssl",
             user_id="u",
         )
-        started = await api.start_push(connection_details=details)
+        with pytest.raises(ActronAirAuthError):
+            await api.start_push(connection_details=details)
 
-        assert started is False
         assert api._rt_client is None
+        assert api._push_running is False
 
     @pytest.mark.asyncio
     async def test_start_push_cleans_up_local_client_on_subscribe_failure(self) -> None:
@@ -1627,6 +1632,57 @@ class TestActronAirAPIRealtimeIntegration:
         assert api._rt_client is None
         assert len(FakeMQTTClient.instances) == 1
         FakeMQTTClient.instances[0].disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_push_transport_failure_logs_debug_without_traceback(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A broker failure is an expected fallback: debug level, no traceback."""
+
+        class FakeMQTTClient:
+            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+                self.disconnect = AsyncMock(return_value=None)
+
+            def register_callback(self, callback: Any) -> None:
+                self.callback = callback
+
+            async def connect(self) -> None:
+                raise MqttError("broker unreachable")
+
+            async def update_access_token(self, token: str) -> None:
+                return None
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test",
+            port=8883,
+            protocol="ssl",
+            user_id="u",
+        )
+
+        from actron_neo_api import actron as actron_module
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = FakeMQTTClient  # type: ignore[assignment]
+            with caplog.at_level(logging.DEBUG, logger="actron_neo_api.actron"):
+                started = await api.start_push(connection_details=details)
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert started is False
+        assert api._rt_client is None
+        assert api._push_running is False
+        records = [record for record in caplog.records if record.name == "actron_neo_api.actron"]
+        assert records
+        assert all(record.levelno == logging.DEBUG for record in records)
+        assert all(record.exc_info is None for record in records)
+        assert "Realtime push unavailable (broker unreachable)" in caplog.text
 
     @pytest.mark.asyncio
     async def test_start_push_event_callback_creates_background_task(
@@ -1693,6 +1749,117 @@ class TestActronAirAPIRealtimeIntegration:
         api = ActronAirAPI()
         with pytest.raises(ValueError, match="serial_number cannot be empty"):
             api.subscribe_system_updates("", lambda _: None)
+
+    @pytest.mark.asyncio
+    async def test_subscribe_system_updates_unsubscribe_stops_callback(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """The returned callable should remove only its own registration."""
+        api = ActronAirAPI()
+        api._push_running = True
+        first: list[str] = []
+        second: list[str] = []
+
+        unsubscribe = api.subscribe_system_updates("ABC123", lambda status: first.append("a"))
+        api.subscribe_system_updates("ABC123", lambda status: second.append("b"))
+
+        status = ActronAirStatus.model_validate(sample_status_full)
+        status.serial_number = "abc123"
+        event = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/full-status",
+            payload={},
+            domain_model=status,
+        )
+
+        await api._handle_realtime_event(event)
+        unsubscribe()
+        await api._handle_realtime_event(event)
+
+        assert first == ["a"]
+        assert second == ["b", "b"]
+
+    def test_subscribe_system_updates_unsubscribe_is_idempotent(self) -> None:
+        """Calling the remove-callback twice should not raise."""
+        api = ActronAirAPI()
+
+        def _cb(_status: ActronAirStatus) -> None:
+            return None
+
+        unsubscribe = api.subscribe_system_updates("ABC123", _cb)
+        unsubscribe()
+        unsubscribe()
+
+        assert "abc123" not in api._push_callbacks
+
+        # Repeat with a sibling subscription keeping the serial's list alive.
+        other_unsubscribe = api.subscribe_system_updates("ABC123", _cb)
+        unsubscribe = api.subscribe_system_updates("ABC123", lambda _status: None)
+        unsubscribe()
+        unsubscribe()
+
+        assert len(api._push_callbacks["abc123"]) == 1
+        other_unsubscribe()
+        assert "abc123" not in api._push_callbacks
+
+    @pytest.mark.asyncio
+    async def test_subscribe_connection_state_receives_events(self) -> None:
+        """Connection events should reach sync and async subscribers."""
+        api = ActronAirAPI()
+        sync_seen: list[RealtimeConnectionState] = []
+        async_seen: list[RealtimeConnectionState] = []
+
+        async def _async_cb(event: RealtimeConnectionEvent) -> None:
+            async_seen.append(event.state)
+
+        api.subscribe_connection_state(lambda event: sync_seen.append(event.state))
+        api.subscribe_connection_state(_async_cb)
+
+        event = RealtimeConnectionEvent(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.CONNECTION,
+            state=RealtimeConnectionState.CONNECTED,
+            previous_state=RealtimeConnectionState.CONNECTING,
+        )
+        await api._handle_realtime_event(event)
+
+        assert sync_seen == [RealtimeConnectionState.CONNECTED]
+        assert async_seen == [RealtimeConnectionState.CONNECTED]
+
+    @pytest.mark.asyncio
+    async def test_subscribe_connection_state_unsubscribe_and_error_handling(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A failing callback should be logged, and unsubscribe should detach it."""
+        api = ActronAirAPI()
+
+        def _boom(_event: RealtimeConnectionEvent) -> None:
+            raise RuntimeError("callback exploded")
+
+        unsubscribe = api.subscribe_connection_state(_boom)
+
+        event = RealtimeConnectionEvent(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.CONNECTION,
+            state=RealtimeConnectionState.ERROR,
+            reason="broker gone",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="actron_neo_api.actron"):
+            await api._handle_realtime_event(event)
+
+        assert "Realtime connection callback failed for error" in caplog.text
+
+        caplog.clear()
+        unsubscribe()
+        unsubscribe()
+        with caplog.at_level(logging.WARNING, logger="actron_neo_api.actron"):
+            await api._handle_realtime_event(event)
+
+        assert caplog.text == ""
+        assert api._push_connection_callbacks == []
 
     @pytest.mark.asyncio
     async def test_stream_system_updates_skips_non_matching_serial(

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -775,31 +775,6 @@ class TestMQTTRTClient:
         assert captured["identifier"] == client._client_id  # noqa: SLF001 - kwarg regression check
         assert isinstance(captured["tls_context"], ssl.SSLContext)
 
-    def test_get_client_identifier_arg_name_legacy_client_id(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Older aiomqtt variants using client_id should still be supported."""
-
-        class _LegacyClient:
-            def __init__(self, *, client_id: str | None = None) -> None:
-                self.client_id = client_id
-
-        monkeypatch.setattr(mqtt_module, "Client", _LegacyClient)
-
-        assert MQTTRTClient._get_client_identifier_arg_name() == "client_id"  # noqa: SLF001
-
-    def test_get_client_identifier_arg_name_signature_failure(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Signature inspection failures should fall back to the modern identifier kwarg."""
-
-        def raise_type_error(_obj: object) -> None:
-            raise TypeError("signature unavailable")
-
-        monkeypatch.setattr(mqtt_module.inspect, "signature", raise_type_error)
-
-        assert MQTTRTClient._get_client_identifier_arg_name() == "identifier"  # noqa: SLF001
-
     @pytest.mark.asyncio
     async def test_iter_events_yields_queued_events(self) -> None:
         """Queued events should be yielded in order."""


### PR DESCRIPTION
Prepares the library for Home Assistant Core review, so the integration does not have to work around library limitations ("integrations should not implement workarounds for library limitations — the library should be updated"). Intended to ship as 0.6.0.

## Changes

**`subscribe_system_updates()` returns a remove-callback.** It now returns `Callable[[], None]`, matching HA's `CALLBACK_TYPE` idiom. Calling it more than once is safe, and it removes only its own registration when several callbacks share a serial. Non-breaking: the method previously returned `None`, so existing callers are unaffected.

**New `subscribe_connection_state(callback)`.** Both transports already emitted `RealtimeConnectionEvent` through the same callback path, but `_handle_realtime_event()` discarded everything that wasn't a `RealtimeMessage`. Those transitions (`connecting`, `connected`, `reconnecting`, `disconnected`, `error`) are now dispatched to subscribers. Connection state belongs to the transport rather than a single system, so one callback covers every subscribed serial. Sync and async callbacks are both supported, and an exception raised in one is logged without disrupting the transport. Also returns a remove-callback.

**`start_push()` no longer swallows every exception.** The single `except Exception` became three branches:

- `ActronAirAuthError` is re-raised after cleanup, so callers can trigger reauth instead of silently degrading to polling that would fail the same way.
- Expected transport failures (`ActronAirAPIError`, `MqttError`, `aiohttp.ClientError`, `OSError`) log at debug with no traceback and return `False` — falling back to polling is normal operation, not an operator-facing problem. `"Realtime connection details unavailable"` moved from info to debug for the same reason.
- Anything else keeps `_LOGGER.exception` so genuine bugs stay visible.

Cleanup is shared in `_cleanup_failed_push()`, so the transport is disconnected and `_push_running` reset on every failure path.

**aiomqtt floor raised to `>=2.0.0`.** The code already used the 2.x API. This let the `client_id`/`identifier` signature-sniffing shim be deleted in favour of passing `identifier=` directly. Verified against aiomqtt 2.5.1 that both `identifier` and `clean_session` remain valid kwargs.

## Compatibility

The one behavior change for existing callers is that `start_push()` now raises `ActronAirAuthError` where it previously returned `False`. This is deliberate — it is what lets the HA integration raise `ConfigEntryAuthFailed` — but it means the integration must wrap the call, so the HA-side change is coupled to this release.

## Verification

525 tests pass; ruff and mypy clean; `actron.py` back at 100% coverage. Two existing tests were updated for the new auth contract and debug-level logging, and the two tests covering the deleted aiomqtt shim were removed. New tests cover unsubscribe (including idempotency and sibling subscriptions), connection-state dispatch for sync/async callbacks, callback error handling, and the debug-without-traceback transport-failure path.

Docs updated in README, `docs/rt_push_implementation.md`, and `realtime_example.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
