### PR TITLE
fix: parse Neo status-change and full-status broadcast payloads

### DIFF
--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import re
 from collections.abc import AsyncIterator, Awaitable, Callable
 from copy import deepcopy
 from typing import Any, Literal
@@ -44,6 +45,9 @@ from .rt import (
 from .state import StateManager
 
 _LOGGER = logging.getLogger(__name__)
+
+# Segments of a flat broadcast key: a name, or a bracketed list index.
+_FLAT_KEY_SEGMENT_RE = re.compile(r"([^.\[\]]+)|\[(\d+)\]")
 
 
 class _PendingBatch:
@@ -904,6 +908,47 @@ class ActronAirAPI:
         if self._is_mqtt_status_change_topic(event.topic):
             return await self._merge_mqtt_status_change(serial, event.payload)
 
+        if self._is_mqtt_full_status_topic(event.topic):
+            # The transport builds domain_model from the raw payload, which
+            # silently validates a broadcast wrapper into an all-defaults
+            # status, so the broadcast shape has to win where it applies.
+            broadcast = self._parse_full_status_broadcast(serial, event.payload)
+            if broadcast is not None:
+                return broadcast
+
+        return status
+
+    @staticmethod
+    def _parse_full_status_broadcast(
+        serial: str,
+        payload: dict[str, Any],
+    ) -> ActronAirStatus | None:
+        """Parse a Neo full-status-broadcast payload into a status model.
+
+        The broker wraps the complete state in ``payload["event"]`` rather than
+        the ``{"lastKnownState": {...}}`` shape used by the HTTP API.
+
+        Returns:
+            The parsed status, or None if the payload is not a full-status
+            broadcast or cannot be validated.
+        """
+        event = payload.get("event")
+        if not isinstance(event, dict) or event.get("type") != "full-status-broadcast":
+            return None
+
+        last_known_state = {key: value for key, value in event.items() if key != "type"}
+        if not last_known_state:
+            return None
+
+        try:
+            status = ActronAirStatus.model_validate(
+                {"isOnline": True, "lastKnownState": last_known_state}
+            )
+        except Exception as exc:
+            _LOGGER.warning("Failed to parse full-status broadcast for %s: %s", serial, exc)
+            return None
+
+        status.serial_number = serial
         return status
 
     async def _merge_mqtt_status_change(
@@ -926,8 +971,11 @@ class ActronAirAPI:
             "lastKnownState": deepcopy(existing_status.last_known_state),
         }
 
+        broadcast = self._status_change_broadcast(payload)
         delta_state = payload.get("lastKnownState")
-        if isinstance(delta_state, dict):
+        if broadcast is not None:
+            self._apply_broadcast_delta(merged_status_data["lastKnownState"], broadcast, serial)
+        elif isinstance(delta_state, dict):
             self._deep_merge_dicts(merged_status_data["lastKnownState"], delta_state)
         else:
             state_updates = {
@@ -984,6 +1032,139 @@ class ActronAirAPI:
         return self.state_manager.get_status(serial)
 
     @staticmethod
+    def _status_change_broadcast(payload: dict[str, Any]) -> dict[str, Any] | None:
+        """Return the state-bearing body of a status-change-broadcast payload.
+
+        Neo wraps realtime deltas in ``payload["event"]`` with a ``type``
+        marker; every other key in that dict is a state delta.
+        """
+        event = payload.get("event")
+        if not isinstance(event, dict) or event.get("type") != "status-change-broadcast":
+            return None
+        body = {key: value for key, value in event.items() if key != "type"}
+        return body or None
+
+    @classmethod
+    def _apply_broadcast_delta(
+        cls,
+        last_known_state: dict[str, Any],
+        broadcast: dict[str, Any],
+        serial: str,
+    ) -> None:
+        """Apply flat-notation broadcast deltas onto a lastKnownState snapshot."""
+        for key, value in broadcast.items():
+            path = cls._parse_flat_key_path(key)
+            if not cls._apply_flat_path_to_dict(last_known_state, path, value):
+                _LOGGER.debug("Skipped unmappable status-change key %r for %s", key, serial)
+
+    @staticmethod
+    def _parse_flat_key_path(key: str) -> list[str | int]:
+        """Parse a flat broadcast key into a path of dict keys and list indices.
+
+        Examples:
+            ``UserAirconSettings.EnabledZones[6]`` -> ``["UserAirconSettings",
+            "EnabledZones", 6]``; ``RemoteZoneInfo[1].ZonePosition`` ->
+            ``["RemoteZoneInfo", 1, "ZonePosition"]``.
+
+        Peripheral identifiers are wrapped in angle brackets and contain dots
+        that belong to the identifier, so they stay a single literal segment.
+        """
+        if key.startswith("<") and key.endswith(">"):
+            return [key]
+
+        path: list[str | int] = []
+        for name, index in _FLAT_KEY_SEGMENT_RE.findall(key):
+            path.append(name if name else int(index))
+        return path
+
+    @classmethod
+    def _apply_flat_path_to_dict(
+        cls,
+        last_known_state: dict[str, Any],
+        path: list[str | int],
+        value: Any,
+    ) -> bool:
+        """Write value into a nested structure, creating containers as needed.
+
+        Each container is coerced to the type the next path segment requires,
+        so a broadcast that disagrees with the cached shape replaces the stale
+        container instead of raising.
+
+        Returns:
+            True if the value was written, False if the path was unusable.
+        """
+        if not path:
+            return False
+
+        current: Any = last_known_state
+        for depth, segment in enumerate(path[:-1]):
+            wanted: type = list if isinstance(path[depth + 1], int) else dict
+            current = cls._descend_flat_path(current, segment, wanted)
+            if current is None:
+                return False
+
+        return cls._set_flat_path_leaf(current, path[-1], value)
+
+    @classmethod
+    def _descend_flat_path(
+        cls,
+        container: Any,
+        segment: str | int,
+        wanted: type,
+    ) -> Any:
+        """Return the child container at segment, creating it when needed.
+
+        A returned container always matches *wanted*, so the next segment is
+        guaranteed a container it can address.
+        """
+        if isinstance(segment, int):
+            if not isinstance(container, list):
+                return None
+            while len(container) <= segment:
+                container.append(None)
+            if not cls._replaceable_child(container[segment], wanted):
+                return container[segment] if isinstance(container[segment], wanted) else None
+            container[segment] = wanted()
+            return container[segment]
+
+        existing = container.get(segment)
+        if not cls._replaceable_child(existing, wanted):
+            return existing if isinstance(existing, wanted) else None
+        container[segment] = wanted()
+        return container[segment]
+
+    @staticmethod
+    def _replaceable_child(existing: Any, wanted: type) -> bool:
+        """Return whether an existing child may be replaced with a fresh container.
+
+        A missing or scalar child is safe to replace, as is an empty container
+        of the wrong type. A populated container of the wrong type is left
+        alone: a malformed key must not discard cached state.
+        """
+        if isinstance(existing, wanted):
+            return False
+        if isinstance(existing, (dict, list)):
+            return not existing
+        return True
+
+    @staticmethod
+    def _set_flat_path_leaf(container: Any, segment: str | int, value: Any) -> bool:
+        """Assign value at the final path segment, if the container allows it.
+
+        Only an indexed segment can mismatch here: a named segment always
+        lands on a dict, either the lastKnownState root or a container that
+        :meth:`_descend_flat_path` created as one.
+        """
+        if isinstance(segment, int):
+            if not isinstance(container, list):
+                return False
+            while len(container) <= segment:
+                container.append(None)
+
+        container[segment] = value
+        return True
+
+    @staticmethod
     def _deep_merge_dicts(base: dict[str, Any], updates: dict[str, Any]) -> None:
         """Recursively merge updates into base in place."""
         for key, value in updates.items():
@@ -997,6 +1178,8 @@ class ActronAirAPI:
         """Return whether a Neo status-change payload contains state-bearing fields."""
         metadata_only_keys = ActronAirAPI._mqtt_status_change_metadata_keys()
         if isinstance(payload.get("lastKnownState"), dict):
+            return True
+        if ActronAirAPI._status_change_broadcast(payload) is not None:
             return True
         return any(key not in metadata_only_keys for key in payload)
 
@@ -1019,6 +1202,11 @@ class ActronAirAPI:
     def _is_mqtt_status_change_topic(topic: str) -> bool:
         """Return whether a realtime topic is the Neo status-change channel."""
         return topic.endswith("/mwc/status-change")
+
+    @staticmethod
+    def _is_mqtt_full_status_topic(topic: str) -> bool:
+        """Return whether a realtime topic is the Neo full-status channel."""
+        return topic.endswith("/mwc/full-status")
 
     @staticmethod
     def _extract_realtime_serial(

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -2188,3 +2188,322 @@ class TestActronAirAPIRealtimeIntegration:
             domain_model=status,
         )
         assert ActronAirAPI._extract_realtime_serial(msg_none, status) is None
+
+
+class TestNeoBroadcastPayloads:
+    """Test Neo status-change-broadcast and full-status-broadcast handling."""
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("UserAirconSettings.EnabledZones[6]", ["UserAirconSettings", "EnabledZones", 6]),
+            ("RemoteZoneInfo[1].ZonePosition", ["RemoteZoneInfo", 1, "ZonePosition"]),
+            ("MasterInfo.LiveTemp_oC", ["MasterInfo", "LiveTemp_oC"]),
+            ("isOn", ["isOn"]),
+            # Peripheral identifiers carry dots that belong to the identifier.
+            ("<28.8f.4d.a4.e2.6a>", ["<28.8f.4d.a4.e2.6a>"]),
+            ("", []),
+        ],
+    )
+    def test_parse_flat_key_path(self, key: str, expected: list[str | int]) -> None:
+        """Flat broadcast keys should parse into dict keys and list indices."""
+        assert ActronAirAPI._parse_flat_key_path(key) == expected
+
+    @pytest.mark.parametrize(
+        ("state", "key", "value", "applied", "expected"),
+        [
+            pytest.param(
+                {"UserAirconSettings": {"EnabledZones": [False, False]}},
+                "UserAirconSettings.EnabledZones[1]",
+                True,
+                True,
+                {"UserAirconSettings": {"EnabledZones": [False, True]}},
+                id="zone_toggle",
+            ),
+            pytest.param(
+                {},
+                "RemoteZoneInfo[1].ZonePosition",
+                42,
+                True,
+                {"RemoteZoneInfo": [None, {"ZonePosition": 42}]},
+                id="creates_missing_containers",
+            ),
+            pytest.param(
+                {"RemoteZoneInfo": {}},
+                "RemoteZoneInfo[0].ZonePosition",
+                5,
+                True,
+                {"RemoteZoneInfo": [{"ZonePosition": 5}]},
+                id="empty_container_is_coerced",
+            ),
+            pytest.param(
+                {"RemoteZoneInfo": [{"ZonePosition": 1}]},
+                "RemoteZoneInfo.Bogus",
+                9,
+                False,
+                {"RemoteZoneInfo": [{"ZonePosition": 1}]},
+                id="populated_list_is_never_discarded",
+            ),
+            pytest.param(
+                {"UserAirconSettings": {"Mode": "COOL"}},
+                "UserAirconSettings[0]",
+                9,
+                False,
+                {"UserAirconSettings": {"Mode": "COOL"}},
+                id="populated_dict_is_never_discarded",
+            ),
+            pytest.param(
+                {"MasterInfo": {"LiveTemp_oC": 1.0}},
+                "MasterInfo.LiveTemp_oC",
+                23.5,
+                True,
+                {"MasterInfo": {"LiveTemp_oC": 23.5}},
+                id="scalar_leaf",
+            ),
+            pytest.param(
+                {"MasterInfo": 5},
+                "MasterInfo.LiveTemp_oC",
+                23.5,
+                True,
+                {"MasterInfo": {"LiveTemp_oC": 23.5}},
+                id="scalar_container_is_replaced",
+            ),
+            pytest.param(
+                {"UserAirconSettings": {"EnabledZones": [False, False]}},
+                "UserAirconSettings.EnabledZones[3]",
+                True,
+                True,
+                {"UserAirconSettings": {"EnabledZones": [False, False, None, True]}},
+                id="leaf_index_past_end_is_padded",
+            ),
+            pytest.param({}, "", 1, False, {}, id="empty_path"),
+        ],
+    )
+    def test_apply_flat_path_to_dict(
+        self,
+        state: dict[str, Any],
+        key: str,
+        value: Any,
+        applied: bool,
+        expected: dict[str, Any],
+    ) -> None:
+        """Broadcast deltas should write into state without discarding it."""
+        path = ActronAirAPI._parse_flat_key_path(key)
+
+        assert ActronAirAPI._apply_flat_path_to_dict(state, path, value) is applied
+        assert state == expected
+
+    def test_apply_flat_path_rejects_index_into_dict_root(self) -> None:
+        """An indexed first segment cannot address the lastKnownState dict."""
+        state: dict[str, Any] = {}
+
+        assert ActronAirAPI._apply_flat_path_to_dict(state, [0, "Nested"], 1) is False
+        assert ActronAirAPI._apply_flat_path_to_dict(state, [0], 1) is False
+        assert state == {}
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            pytest.param({}, None, id="no_event"),
+            pytest.param({"event": "text"}, None, id="event_not_a_dict"),
+            pytest.param(
+                {"event": {"type": "full-status-broadcast"}}, None, id="wrong_broadcast_type"
+            ),
+            pytest.param({"event": {"type": "status-change-broadcast"}}, None, id="type_only_body"),
+            pytest.param(
+                {"event": {"type": "status-change-broadcast", "isOn": True}},
+                {"isOn": True},
+                id="state_bearing",
+            ),
+        ],
+    )
+    def test_status_change_broadcast_detection(
+        self, payload: dict[str, Any], expected: dict[str, Any] | None
+    ) -> None:
+        """Only state-bearing status-change broadcasts should be recognised."""
+        assert ActronAirAPI._status_change_broadcast(payload) == expected
+
+    def test_broadcast_payload_counts_as_state(self) -> None:
+        """A broadcast must not be treated as metadata-only.
+
+        "event" is a metadata key, so without this the whole delta falls
+        through to an HTTP refresh of the stale cloud snapshot.
+        """
+        payload = {
+            "event": {
+                "type": "status-change-broadcast",
+                "UserAirconSettings.EnabledZones[6]": True,
+            },
+            "serial": "abc123",
+            "isOnline": True,
+        }
+
+        assert ActronAirAPI._mqtt_status_change_contains_state(payload) is True
+
+    @pytest.mark.asyncio
+    async def test_status_change_broadcast_merges_without_http_refresh(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """Zone deltas from the device should be applied to the cached state."""
+        api = ActronAirAPI(platform="neo")
+        api._push_running = True
+        api.state_manager.process_status_update("abc123", sample_status_full)
+        api.update_status = AsyncMock(side_effect=AssertionError("must not refresh over HTTP"))
+
+        event = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/status-change",
+            payload={
+                "event": {
+                    "type": "status-change-broadcast",
+                    "UserAirconSettings.EnabledZones[1]": True,
+                    "RemoteZoneInfo[0].ZonePosition": 50.0,
+                    "MasterInfo.LiveTemp_oC": 26.5,
+                },
+                "serial": "abc123",
+            },
+            domain_model=None,
+        )
+
+        await api._handle_realtime_event(event)
+
+        status = api.state_manager.get_status("abc123")
+        assert status is not None
+        assert status.user_aircon_settings.enabled_zones[1] is True
+        assert status.remote_zone_info[0].zone_position == 50.0
+        assert status.master_info.live_temp_c == 26.5
+        # Untouched fields must survive the delta.
+        assert status.user_aircon_settings.mode == "COOL"
+
+    @pytest.mark.asyncio
+    async def test_status_change_broadcast_logs_unmappable_keys(
+        self,
+        sample_status_full: dict[str, Any],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A key that cannot be mapped is skipped rather than corrupting state."""
+        api = ActronAirAPI(platform="neo")
+        api._push_running = True
+        api.state_manager.process_status_update("abc123", sample_status_full)
+
+        event = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/status-change",
+            payload={
+                "event": {
+                    "type": "status-change-broadcast",
+                    "RemoteZoneInfo.Bogus": 1,
+                }
+            },
+            domain_model=None,
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="actron_neo_api.actron"):
+            await api._handle_realtime_event(event)
+
+        assert "Skipped unmappable status-change key" in caplog.text
+        status = api.state_manager.get_status("abc123")
+        assert status is not None
+        assert status.remote_zone_info[0].zone_position == 100.0
+
+    @pytest.mark.asyncio
+    async def test_full_status_broadcast_replaces_zeroed_domain_model(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """A broadcast wrapper must win over the transport's all-defaults model.
+
+        ActronAirStatus validates the wrapper successfully but with every field
+        defaulted, so without this the push would overwrite good state with
+        zeroes.
+        """
+        api = ActronAirAPI(platform="neo")
+        api._push_running = True
+
+        zeroed = ActronAirStatus.model_validate(
+            {"event": {"type": "full-status-broadcast", **sample_status_full["lastKnownState"]}}
+        )
+        assert zeroed.user_aircon_settings.mode == ""
+
+        event = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/full-status",
+            payload={
+                "event": {
+                    "type": "full-status-broadcast",
+                    **sample_status_full["lastKnownState"],
+                }
+            },
+            domain_model=zeroed,
+        )
+
+        await api._handle_realtime_event(event)
+
+        status = api.state_manager.get_status("abc123")
+        assert status is not None
+        assert status.user_aircon_settings.mode == "COOL"
+        assert status.master_info.live_temp_c == 22.5
+        assert status.is_online is True
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param({}, id="no_event"),
+            pytest.param({"event": ["not", "a", "dict"]}, id="event_not_a_dict"),
+            pytest.param({"event": {"type": "status-change-broadcast"}}, id="wrong_type"),
+            pytest.param({"event": {"type": "full-status-broadcast"}}, id="empty_body"),
+        ],
+    )
+    def test_parse_full_status_broadcast_rejects(self, payload: dict[str, Any]) -> None:
+        """Payloads that are not full-status broadcasts should not be parsed."""
+        assert ActronAirAPI._parse_full_status_broadcast("abc123", payload) is None
+
+    def test_parse_full_status_broadcast_handles_invalid_state(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A body that cannot be validated should warn instead of raising."""
+
+        def _raise_validate(_: Any) -> ActronAirStatus:
+            raise ValueError("broadcast boom")
+
+        monkeypatch.setattr(
+            ActronAirStatus,
+            "model_validate",
+            classmethod(lambda cls, payload: _raise_validate(payload)),
+        )
+
+        payload = {"event": {"type": "full-status-broadcast", "UserAirconSettings": {}}}
+
+        with caplog.at_level(logging.WARNING, logger="actron_neo_api.actron"):
+            result = ActronAirAPI._parse_full_status_broadcast("abc123", payload)
+
+        assert result is None
+        assert "Failed to parse full-status broadcast for abc123" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_non_broadcast_full_status_still_uses_domain_model(
+        self, sample_status_full: dict[str, Any]
+    ) -> None:
+        """The original full-status shape must keep working."""
+        api = ActronAirAPI(platform="neo")
+        api._push_running = True
+        status = ActronAirStatus.model_validate(sample_status_full)
+
+        event = RealtimeMessage(
+            transport=RealtimeTransportType.MQTT,
+            kind=RealtimeEventKind.MESSAGE,
+            topic="actron-cloud/u/neo/abc123/mwc/full-status",
+            payload=sample_status_full,
+            domain_model=status,
+        )
+
+        assert await api._coerce_realtime_status(event) is status
+
+    def test_is_mqtt_full_status_topic(self) -> None:
+        """Only the full-status channel should match."""
+        assert ActronAirAPI._is_mqtt_full_status_topic("a/b/mwc/full-status") is True
+        assert ActronAirAPI._is_mqtt_full_status_topic("a/b/mwc/status-change") is False


### PR DESCRIPTION
Takes the two real bug fixes from #90 (by @KieraDOG, who diagnosed both against live Neo hardware and did the field testing) and lands them with tests. The `getAll` handshake and the TLS `verify_mode` change from that PR are deliberately left out — see below.

## The bugs

Neo pushes realtime state inside an `event` wrapper that the library did not understand, in two shapes.

**1. `status-change-broadcast` deltas were discarded.** State arrives as flat dot/index keys inside `event`:

```json
{"event": {"type": "status-change-broadcast",
           "UserAirconSettings.EnabledZones[6]": true,
           "RemoteZoneInfo[1].ZonePosition": 50.0}}
```

`"event"` is listed in `_mqtt_status_change_metadata_keys()`, so the whole payload read as metadata-only and fell through to an HTTP refresh of the cloud's stale `lastKnownState`. Every zone change made at the wall controller was dropped.

**2. `full-status-broadcast` overwrote good state with zeroes.** The same wrapper carries the complete state on the full-status topic. This does *not* fail validation — it validates cleanly into an all-defaults `ActronAirStatus` (`is_on=False`, `mode=""`, `live_temp=0.0`, no zones), which then flowed into `process_status_update` and replaced correct cached state. Worse than stale data: actively wrong data.

## Changes

- `_status_change_broadcast()` recognises the wrapper, and `_mqtt_status_change_contains_state()` now treats it as state-bearing so it no longer triggers an HTTP refresh.
- `_parse_full_status_broadcast()` parses the wrapper into a status model, and `_coerce_realtime_status()` prefers it over the transport's `domain_model` on the full-status topic. The original `{"lastKnownState": ...}` shape still uses `domain_model` as before.
- `_parse_flat_key_path()` / `_apply_flat_path_to_dict()` apply flat keys, creating containers along the path as needed.

Two rules stop a malformed key from corrupting state:

- **Peripheral identifiers stay literal.** `<28.8f.4d.a4.e2.6a>` is one key, not six path segments — splitting it on its dots wrote `{"28": {"8f": {"4d": ...}}}` into `lastKnownState`.
- **A populated container is never replaced by one of a different type.** A key like `RemoteZoneInfo.Bogus` would otherwise replace the whole zone list with a dict. Such keys are skipped and logged at debug instead. Empty containers are still coerced, since there is no data to lose.

## Not included from #90

- **The `getAll` handshake on connect.** It adds up to 5 s of blocking inside `start_push()`, which lands directly on Home Assistant config-entry setup time, and it sends `getAll` to `serials[0]` only while waiting for every serial to report — so a multi-system account would always hit the timeout. Worth doing, but as its own change.
- **`verify_mode = ssl.CERT_NONE` for IP-literal endpoints.** `check_hostname = False` already disables the hostname/SAN check, so a remaining `CERTIFICATE_VERIFY_FAILED` means the broker's certificate does not chain to a trusted root — a different problem from the one described. Disabling verification entirely opens the connection to MITM, and Copilot raised the same concern on #90.

## Verification

557 tests pass, 100% coverage maintained, ruff and mypy clean. New tests cover flat-key parsing, the container rules above, broadcast detection, an end-to-end delta merge that asserts no HTTP refresh happens, and the full-status broadcast winning over a zeroed `domain_model`.

I could not verify the payload shapes against live Neo hardware; that rests on @KieraDOG's field testing in #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
