### PR TITLE
Realtime transport fixes: connection-state dispatch, queue retention, SSE timeout, MQTT session identity

### DIFF
--- a/docs/rt_push_implementation.md
+++ b/docs/rt_push_implementation.md
@@ -84,6 +84,34 @@ unsubscribe_connection = api.subscribe_connection_state(on_connection)
 - Que systems are connected through SignalR/SSE.
 - Consumer code does not need to manage the transport directly.
 
+## MQTT Client Identifier (Neo)
+
+`start_push()` accepts an optional `client_id` used as the MQTT client
+identifier. Supplying one that is stable across restarts — a Home Assistant
+config entry id, for example — opts the connection into a persistent broker
+session, so messages published while the client was away are delivered on
+reconnect.
+
+```python
+await api.start_push([serial], client_id=entry.entry_id)
+```
+
+When `client_id` is omitted, a random `HA_`-prefixed identifier is generated and
+a clean session is used instead. A persistent session keyed to an identifier
+that changes every restart would strand a session on the broker each time
+without ever resuming one, so the two settings are chosen together.
+
+Use an identifier that is unique per installation. Two clients connecting with
+the same identifier will repeatedly disconnect each other.
+
+## Event Buffering
+
+Each transport keeps a bounded buffer of recent events for `iter_events()`
+consumers; once it is full the oldest event is dropped rather than retained.
+Callback subscribers (`subscribe_system_updates()`,
+`subscribe_connection_state()`) are delivered to directly and are unaffected by
+the buffer.
+
 ## Fallback Behavior
 
 Push is optional.

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -582,7 +582,11 @@ class ActronAirAPI:
                 raise ActronAirAuthError("No OAuth access token available for realtime transport")
 
             if self.platform == PLATFORM_QUE:
-                rt_client = SignalRRTClient(details, token)
+                # Reuse the API session so an injected one covers the realtime
+                # transport too. The transport only closes a session it created
+                # itself, and every request it makes carries its own timeout,
+                # so the session default never applies to the event stream.
+                rt_client = SignalRRTClient(details, token, session=await self._get_session())
             else:
                 rt_client = MQTTRTClient(
                     details,

--- a/src/actron_neo_api/actron.py
+++ b/src/actron_neo_api/actron.py
@@ -334,7 +334,6 @@ class ActronAirAPI:
         # Realtime push integration (issue #77)
         self._rt_client: MQTTRTClient | SignalRRTClient | None = None
         self._push_running = False
-        self._push_status_queue: asyncio.Queue[tuple[str, ActronAirStatus | None]] = asyncio.Queue()
         self._push_stream_queues: list[
             tuple[str | None, asyncio.Queue[ActronAirStatus | None]]
         ] = []
@@ -527,6 +526,7 @@ class ActronAirAPI:
         serial_numbers: list[str] | None = None,
         *,
         connection_details: RealtimeConnectionDetails | None = None,
+        client_id: str | None = None,
     ) -> bool:
         """Start realtime push updates for one or more systems.
 
@@ -535,6 +535,11 @@ class ActronAirAPI:
                 If omitted, subscribes all known systems (fetching systems if needed).
             connection_details: Optional pre-resolved realtime connection details.
                 If omitted, the client attempts to discover details from API links.
+            client_id: Optional MQTT client identifier for the Neo transport.
+                Supplying one that is stable across restarts (a Home Assistant
+                config entry id, for example) opts the connection into a
+                persistent broker session. Ignored on the Que platform, which
+                does not use MQTT.
 
         Returns:
             True if realtime push started successfully, False if realtime is
@@ -579,7 +584,12 @@ class ActronAirAPI:
             if self.platform == PLATFORM_QUE:
                 rt_client = SignalRRTClient(details, token)
             else:
-                rt_client = MQTTRTClient(details, await self._resolve_mqtt_username(), token)
+                rt_client = MQTTRTClient(
+                    details,
+                    await self._resolve_mqtt_username(),
+                    token,
+                    client_id=client_id,
+                )
 
             if rt_client is None:
                 raise ActronAirAPIError("Failed to create realtime transport client")
@@ -651,7 +661,6 @@ class ActronAirAPI:
         """Stop realtime push updates and disconnect active transport."""
         self._push_running = False
         # Wake blocked stream consumers so they can exit cleanly.
-        self._push_status_queue.put_nowait(("", None))
         for _, stream_queue in list(self._push_stream_queues):
             stream_queue.put_nowait(None)
         if self._rt_client is None:
@@ -881,7 +890,6 @@ class ActronAirAPI:
         current_status = self.state_manager.get_status(serial)
         if current_status is not status:
             self.state_manager.process_status_update(serial, status)
-        await self._push_status_queue.put((serial, status))
         for stream_filter, stream_queue in list(self._push_stream_queues):
             if stream_filter is None or stream_filter == serial:
                 stream_queue.put_nowait(status)

--- a/src/actron_neo_api/rt/base.py
+++ b/src/actron_neo_api/rt/base.py
@@ -7,9 +7,15 @@ surface.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Protocol, runtime_checkable
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_EVENT_QUEUE_MAXSIZE = 256
 
 
 class RealtimeTransportType(str, Enum):
@@ -97,6 +103,40 @@ class RealtimeConnectionDetails:
     def scheme(self) -> str:
         """Return the transport URI scheme."""
         return "ssl" if self.uses_tls else "tcp"
+
+
+def new_event_queue(
+    maxsize: int = DEFAULT_EVENT_QUEUE_MAXSIZE,
+) -> asyncio.Queue[RealtimeEvent]:
+    """Create the bounded queue a transport uses to buffer realtime events."""
+    return asyncio.Queue(maxsize=maxsize)
+
+
+def put_event_dropping_oldest(
+    queue: asyncio.Queue[RealtimeEvent],
+    event: RealtimeEvent,
+) -> None:
+    """Queue an event without blocking, discarding the oldest entry when full.
+
+    Transports emit events whether or not anything consumes ``iter_events``,
+    and the Neo heartbeat topic produces them continuously. Bounding the queue
+    keeps recent events available to a late consumer without retaining every
+    event for the life of the process, and dropping rather than blocking keeps
+    a stalled consumer from stalling the transport.
+    """
+    while True:
+        try:
+            queue.put_nowait(event)
+            return
+        except asyncio.QueueFull:
+            try:
+                dropped = queue.get_nowait()
+            except asyncio.QueueEmpty:  # pragma: no cover - drained concurrently
+                continue
+            _LOGGER.debug(
+                "Realtime event queue is full; dropped the oldest %s",
+                type(dropped).__name__,
+            )
 
 
 @runtime_checkable

--- a/src/actron_neo_api/rt/mqtt_client.py
+++ b/src/actron_neo_api/rt/mqtt_client.py
@@ -22,6 +22,7 @@ from aiomqtt import Client, MqttError
 
 from ..models import ActronAirStatus
 from .base import (
+    DEFAULT_EVENT_QUEUE_MAXSIZE,
     RealtimeConnectionDetails,
     RealtimeConnectionEvent,
     RealtimeConnectionState,
@@ -29,6 +30,8 @@ from .base import (
     RealtimeEventKind,
     RealtimeMessage,
     RealtimeTransportType,
+    new_event_queue,
+    put_event_dropping_oldest,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,13 +72,19 @@ class MQTTRTClient:
             are identifiable on the broker. Blank or whitespace-only values
             fall back to "unknown".
         access_token: OAuth access token used as the MQTT password.
-        client_id: Optional MQTT client identifier. Generated identifiers are
-            prefixed with "HA_" so Home Assistant connections are recognisable.
+        client_id: Optional MQTT client identifier. Supplying one that is
+            stable across restarts (a Home Assistant config entry id, for
+            example) opts the connection into a persistent broker session.
+            When omitted, a random identifier prefixed with "HA_" is generated
+            and a clean session is used instead, so restarts do not strand
+            per-process sessions on the broker.
         ssl_context: Optional custom TLS context.
         keepalive: MQTT keepalive interval in seconds.
         connect_timeout: Time to wait for the first successful connection.
         reconnect_initial_delay: Initial reconnect delay in seconds.
         reconnect_max_delay: Maximum reconnect delay in seconds.
+        event_queue_maxsize: Number of events retained for ``iter_events``
+            consumers before the oldest is dropped.
 
     """
 
@@ -92,6 +101,7 @@ class MQTTRTClient:
         connect_timeout: float = 15.0,
         reconnect_initial_delay: float = _MQTT_DEFAULT_RECONNECT_DELAY,
         reconnect_max_delay: float = _MQTT_MAX_RECONNECT_DELAY,
+        event_queue_maxsize: int = DEFAULT_EVENT_QUEUE_MAXSIZE,
     ) -> None:
         """Initialize the MQTT realtime client."""
         if not access_token.strip():
@@ -104,13 +114,21 @@ class MQTTRTClient:
             raise ValueError("reconnect_initial_delay must be greater than zero")
         if reconnect_max_delay < reconnect_initial_delay:
             raise ValueError("reconnect_max_delay must be greater than or equal to initial delay")
+        if event_queue_maxsize <= 0:
+            raise ValueError("event_queue_maxsize must be greater than zero")
 
         self._details = connection_details
         self._access_token = access_token
         # The broker only uses the username to attribute a connection, so an
         # unusable value is normalized rather than rejected.
         self._user_email = user_email.strip() or _MQTT_UNKNOWN_USERNAME
-        self._client_id = client_id or f"{_MQTT_CLIENT_ID_PREFIX}{uuid.uuid4().hex}"
+        # A persistent broker session is only meaningful with an identifier
+        # that survives a restart. A caller-supplied id is assumed to be stable
+        # and gets one; a generated id would strand a fresh session on the
+        # broker at every restart, so it uses a clean session instead.
+        supplied_client_id = (client_id or "").strip()
+        self._client_id = supplied_client_id or f"{_MQTT_CLIENT_ID_PREFIX}{uuid.uuid4().hex}"
+        self._clean_session = not supplied_client_id
         self._ssl_context = ssl_context
         self._keepalive = keepalive
         self._connect_timeout = connect_timeout
@@ -124,7 +142,7 @@ class MQTTRTClient:
         self._connection_state = RealtimeConnectionState.DISCONNECTED
         self._subscriptions: set[str] = set()
         self._callbacks: list[Callable[[RealtimeEvent], Awaitable[None] | None]] = []
-        self._event_queue: asyncio.Queue[RealtimeEvent] = asyncio.Queue()
+        self._event_queue: asyncio.Queue[RealtimeEvent] = new_event_queue(event_queue_maxsize)
         self._last_error: Exception | None = None
 
     @property
@@ -333,7 +351,7 @@ class MQTTRTClient:
             "username": self._user_email,
             "password": self._access_token,
             "keepalive": self._keepalive,
-            "clean_session": False,
+            "clean_session": self._clean_session,
             "identifier": self._client_id,
         }
         if tls_context is not None:
@@ -407,7 +425,7 @@ class MQTTRTClient:
 
     async def _emit_event(self, event: RealtimeEvent) -> None:
         """Queue an event and notify registered callbacks."""
-        await self._event_queue.put(event)
+        put_event_dropping_oldest(self._event_queue, event)
         for callback in list(self._callbacks):
             try:
                 result = callback(event)
@@ -433,7 +451,9 @@ class MQTTRTClient:
             previous_state=previous_state,
             reason=reason,
         )
-        await self._event_queue.put(event)
+        # Connection events take the same path as messages so callback
+        # subscribers see state transitions, not just queue consumers.
+        await self._emit_event(event)
 
 
 __all__ = ["MQTTRTClient", "NeoMQTTTopicSet"]

--- a/src/actron_neo_api/rt/signalr_client.py
+++ b/src/actron_neo_api/rt/signalr_client.py
@@ -16,12 +16,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any, AsyncIterator, Callable, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 from urllib.parse import quote
 
 import aiohttp
 
 from .base import (
+    DEFAULT_EVENT_QUEUE_MAXSIZE,
     RealtimeClient,
     RealtimeConnectionDetails,
     RealtimeConnectionEvent,
@@ -30,12 +31,14 @@ from .base import (
     RealtimeEventKind,
     RealtimeMessage,
     RealtimeTransportType,
+    new_event_queue,
+    put_event_dropping_oldest,
 )
 
 _LOGGER = logging.getLogger(__name__)
 _SIGNALR_SUBSCRIBE_REFRESH_SECONDS = 300.0
 _SSE_CONNECT_TIMEOUT_SECONDS = 15.0
-_SSE_READ_TIMEOUT_SECONDS = 180.0
+_SSE_DEFAULT_READ_TIMEOUT_SECONDS = 600.0
 _HEALTHY_CONNECTION_SECONDS = 60.0
 
 
@@ -60,6 +63,8 @@ class SignalRRTClient(RealtimeClient):
         session: Optional[aiohttp.ClientSession] = None,
         reconnect_initial_delay: float = 1.0,
         reconnect_max_delay: float = 30.0,
+        stream_read_timeout: float | None = _SSE_DEFAULT_READ_TIMEOUT_SECONDS,
+        event_queue_maxsize: int = DEFAULT_EVENT_QUEUE_MAXSIZE,
     ) -> None:
         """Initialize the SignalRRTClient.
 
@@ -69,6 +74,13 @@ class SignalRRTClient(RealtimeClient):
             session: Optional aiohttp session (for testing/mocking).
             reconnect_initial_delay: Initial reconnect backoff (seconds).
             reconnect_max_delay: Max reconnect backoff (seconds).
+            stream_read_timeout: Seconds of complete silence on the event
+                stream before it is treated as dead and reconnected. This is a
+                socket read timeout, so it resets on every byte received,
+                including SSE keepalive comments. Pass None to disable the
+                check, at the cost of never noticing a half-open connection.
+            event_queue_maxsize: Number of events retained for ``iter_events``
+                consumers before the oldest is dropped.
 
         Raises:
             ValueError: If arguments are invalid.
@@ -79,6 +91,10 @@ class SignalRRTClient(RealtimeClient):
             raise ValueError("reconnect_initial_delay must be greater than zero")
         if reconnect_max_delay < reconnect_initial_delay:
             raise ValueError("reconnect_max_delay must be greater than or equal to initial delay")
+        if stream_read_timeout is not None and stream_read_timeout <= 0:
+            raise ValueError("stream_read_timeout must be greater than zero or None")
+        if event_queue_maxsize <= 0:
+            raise ValueError("event_queue_maxsize must be greater than zero")
 
         self._connection_details = connection_details
         self._access_token = access_token
@@ -86,18 +102,22 @@ class SignalRRTClient(RealtimeClient):
         self._external_session = session is not None
         self._reconnect_initial_delay = reconnect_initial_delay
         self._reconnect_max_delay = reconnect_max_delay
+        self._stream_read_timeout = stream_read_timeout
 
         self._subscriptions: set[str] = set()
-        self._callbacks: list[Callable[[RealtimeEvent], None]] = []
-        self._events: asyncio.Queue[RealtimeEvent] = asyncio.Queue()
+        self._callbacks: list[Callable[[RealtimeEvent], Awaitable[None] | None]] = []
+        self._events: asyncio.Queue[RealtimeEvent] = new_event_queue(event_queue_maxsize)
 
         self._supervisor_task: Optional[asyncio.Task[None]] = None
         self._resubscribe_task: Optional[asyncio.Task[None]] = None
         self._connection_state = RealtimeConnectionState.DISCONNECTED
         self._running = False
 
-    def register_callback(self, callback: Callable[[RealtimeEvent], None]) -> None:
-        """Register a callback to receive realtime events."""
+    def register_callback(
+        self,
+        callback: Callable[[RealtimeEvent], Awaitable[None] | None],
+    ) -> None:
+        """Register a callback that is invoked for every emitted realtime event."""
         self._callbacks.append(callback)
 
     async def connect(self) -> None:
@@ -218,6 +238,10 @@ class SignalRRTClient(RealtimeClient):
                 # without logging a traceback for it.
                 reason = "stream timeout"
                 _LOGGER.debug("SignalR stream timed out; reconnecting in %s", backoff)
+            except (aiohttp.ClientError, OSError) as exc:
+                # Transport drops are expected; the supervisor reconnects.
+                reason = str(exc) or type(exc).__name__
+                _LOGGER.debug("SignalR reconnecting after error: %s", exc, exc_info=True)
             except Exception:  # pragma: no cover - reconnect/backoff loop
                 reason = "transport error"
                 _LOGGER.exception("SignalR supervisor error; reconnecting in %s", backoff)
@@ -254,7 +278,7 @@ class SignalRRTClient(RealtimeClient):
             total=None,
             connect=_SSE_CONNECT_TIMEOUT_SECONDS,
             sock_connect=_SSE_CONNECT_TIMEOUT_SECONDS,
-            sock_read=_SSE_READ_TIMEOUT_SECONDS,
+            sock_read=self._stream_read_timeout,
         )
         async with self._session.get(url, headers=headers, timeout=timeout) as resp:
             if resp.status != 200:
@@ -272,6 +296,13 @@ class SignalRRTClient(RealtimeClient):
                     try:
                         line = raw.decode()
                     except Exception:
+                        continue
+                    if line.startswith(":"):
+                        # An SSE comment is a keepalive and carries no data.
+                        # Logging it makes the server's idle interval
+                        # observable, which is what `stream_read_timeout`
+                        # has to be chosen against.
+                        _LOGGER.debug("sse keepalive: %s", line.strip())
                         continue
                     if line.startswith("data:"):
                         buffer += line[len("data:") :].strip()
@@ -374,12 +405,15 @@ class SignalRRTClient(RealtimeClient):
             _LOGGER.exception("failed to handle incoming signalr payload")
 
     async def _emit_event(self, ev: RealtimeEvent) -> None:
+        """Queue an event and notify registered callbacks."""
+        put_event_dropping_oldest(self._events, ev)
         for cb in list(self._callbacks):
             try:
-                cb(ev)
-            except Exception:
-                _LOGGER.exception("event callback failed")
-        await self._events.put(ev)
+                result = cb(ev)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:  # pragma: no cover - callback failures must not break transport
+                _LOGGER.warning("Realtime event callback failed", exc_info=True)
 
     async def _set_state(
         self,
@@ -397,4 +431,6 @@ class SignalRRTClient(RealtimeClient):
             previous_state=previous_state,
             reason=reason,
         )
-        await self._events.put(event)
+        # Connection events take the same path as messages so callback
+        # subscribers see state transitions, not just queue consumers.
+        await self._emit_event(event)

--- a/src/actron_neo_api/rt/signalr_client.py
+++ b/src/actron_neo_api/rt/signalr_client.py
@@ -34,6 +34,9 @@ from .base import (
 
 _LOGGER = logging.getLogger(__name__)
 _SIGNALR_SUBSCRIBE_REFRESH_SECONDS = 300.0
+_SSE_CONNECT_TIMEOUT_SECONDS = 15.0
+_SSE_READ_TIMEOUT_SECONDS = 180.0
+_HEALTHY_CONNECTION_SECONDS = 60.0
 
 
 class SignalRRTClient(RealtimeClient):
@@ -200,28 +203,34 @@ class SignalRRTClient(RealtimeClient):
             _LOGGER.debug("unsubscribe POST failed", exc_info=True)
 
     async def _run_supervisor(self) -> None:
+        loop = asyncio.get_running_loop()
         backoff = self._reconnect_initial_delay
         while self._running:
+            started = loop.time()
+            reason = "event stream ended"
             try:
                 await self._set_state(RealtimeConnectionState.CONNECTING)
                 await self._connect_and_listen()
-                if self._running:
-                    await self._set_state(
-                        RealtimeConnectionState.RECONNECTING,
-                        reason="event stream ended",
-                    )
-                    await asyncio.sleep(backoff)
-                    backoff = min(self._reconnect_max_delay, backoff * 2)
-                else:
-                    backoff = self._reconnect_initial_delay
             except asyncio.CancelledError:
                 break
+            except asyncio.TimeoutError:
+                # An idle event stream timing out is routine, so reconnect
+                # without logging a traceback for it.
+                reason = "stream timeout"
+                _LOGGER.debug("SignalR stream timed out; reconnecting in %s", backoff)
             except Exception:  # pragma: no cover - reconnect/backoff loop
+                reason = "transport error"
                 _LOGGER.exception("SignalR supervisor error; reconnecting in %s", backoff)
-                await self._set_state(
-                    RealtimeConnectionState.RECONNECTING, reason="transport error"
-                )
-                await asyncio.sleep(backoff)
+            if not self._running:
+                break
+            connected_for = loop.time() - started
+            await self._set_state(RealtimeConnectionState.RECONNECTING, reason=reason)
+            await asyncio.sleep(backoff)
+            if connected_for >= _HEALTHY_CONNECTION_SECONDS:
+                # The connection was healthy for a while, so treat this as a
+                # fresh failure instead of continuing to grow the backoff.
+                backoff = self._reconnect_initial_delay
+            else:
                 backoff = min(self._reconnect_max_delay, backoff * 2)
         await self._set_state(RealtimeConnectionState.DISCONNECTED)
 
@@ -237,7 +246,17 @@ class SignalRRTClient(RealtimeClient):
             sse_url = self._connection_details.endpoint
 
         url = sse_url
-        async with self._session.get(url, headers=headers) as resp:
+        # The event stream is long-lived, so no total timeout may be applied:
+        # aiohttp's default (5 minutes) tears down an otherwise healthy
+        # connection. `sock_read` still detects a stalled stream and resets on
+        # every byte received.
+        timeout = aiohttp.ClientTimeout(
+            total=None,
+            connect=_SSE_CONNECT_TIMEOUT_SECONDS,
+            sock_connect=_SSE_CONNECT_TIMEOUT_SECONDS,
+            sock_read=_SSE_READ_TIMEOUT_SECONDS,
+        )
+        async with self._session.get(url, headers=headers, timeout=timeout) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"sse connect failed: {resp.status}")
             # restore subscriptions immediately after a successful connection

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -991,7 +991,11 @@ class TestActronAirAPIRealtimeIntegration:
 
         class FakeMQTTClient:
             def __init__(
-                self, details: RealtimeConnectionDetails, user_email: str, token: str
+                self,
+                details: RealtimeConnectionDetails,
+                user_email: str,
+                token: str,
+                client_id: str | None = None,
             ) -> None:
                 self.details = details
                 self.user_email = user_email
@@ -1057,7 +1061,11 @@ class TestActronAirAPIRealtimeIntegration:
 
         class FakeMQTTClient:
             def __init__(
-                self, details: RealtimeConnectionDetails, user_email: str, token: str
+                self,
+                details: RealtimeConnectionDetails,
+                user_email: str,
+                token: str,
+                client_id: str | None = None,
             ) -> None:
                 self.user_email = user_email
 
@@ -1577,7 +1585,11 @@ class TestActronAirAPIRealtimeIntegration:
 
         class FakeMQTTClient:
             def __init__(
-                self, details: RealtimeConnectionDetails, user_email: str, token: str
+                self,
+                details: RealtimeConnectionDetails,
+                user_email: str,
+                token: str,
+                client_id: str | None = None,
             ) -> None:
                 self.subscribed: list[str] = []
 
@@ -1686,7 +1698,11 @@ class TestActronAirAPIRealtimeIntegration:
             instances: list["FakeMQTTClient"] = []
 
             def __init__(
-                self, details: RealtimeConnectionDetails, user_email: str, token: str
+                self,
+                details: RealtimeConnectionDetails,
+                user_email: str,
+                token: str,
+                client_id: str | None = None,
             ) -> None:
                 self.disconnect = AsyncMock(return_value=None)
                 FakeMQTTClient.instances.append(self)
@@ -1741,7 +1757,11 @@ class TestActronAirAPIRealtimeIntegration:
 
         class FakeMQTTClient:
             def __init__(
-                self, details: RealtimeConnectionDetails, user_email: str, token: str
+                self,
+                details: RealtimeConnectionDetails,
+                user_email: str,
+                token: str,
+                client_id: str | None = None,
             ) -> None:
                 self.disconnect = AsyncMock(return_value=None)
 
@@ -1796,7 +1816,11 @@ class TestActronAirAPIRealtimeIntegration:
 
         class FakeMQTTClient:
             def __init__(
-                self, details: RealtimeConnectionDetails, user_email: str, token: str
+                self,
+                details: RealtimeConnectionDetails,
+                user_email: str,
+                token: str,
+                client_id: str | None = None,
             ) -> None:
                 self.callback: Any = None
 
@@ -2616,3 +2640,110 @@ class TestNeoBroadcastPayloads:
         """Only the full-status channel should match."""
         assert ActronAirAPI._is_mqtt_full_status_topic("a/b/mwc/full-status") is True
         assert ActronAirAPI._is_mqtt_full_status_topic("a/b/mwc/status-change") is False
+
+
+class TestActronAirAPIConnectionStateWiring:
+    """End-to-end coverage of the transport-to-subscriber dispatch chain."""
+
+    @pytest.mark.asyncio
+    async def test_transport_state_change_reaches_subscribers(self) -> None:
+        """A real transport's state change must reach subscribe_connection_state.
+
+        The chain under test is the one Home Assistant relies on:
+        transport._set_state -> transport callbacks -> _handle_realtime_event
+        -> _dispatch_connection_event -> connection-state subscribers. Faking
+        the transport here would skip the hop that was broken.
+        """
+        from actron_neo_api import actron as actron_module
+        from actron_neo_api.rt.mqtt_client import MQTTRTClient
+
+        class _StubbedTransport(MQTTRTClient):
+            """A real transport with only the broker interaction stubbed out."""
+
+            async def connect(self) -> None:
+                return None
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def subscribe_system(
+                self,
+                device_serial: str,
+                machine_id: str | None = None,
+            ) -> Any:
+                return None
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(return_value=None)
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        seen: list[RealtimeConnectionEvent] = []
+        api.subscribe_connection_state(seen.append)
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test", port=8883, protocol="ssl", user_id="u"
+        )
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = _StubbedTransport  # type: ignore[assignment]
+            assert await api.start_push(connection_details=details) is True
+            transport = api._rt_client
+            assert isinstance(transport, _StubbedTransport)
+            await transport._set_state(RealtimeConnectionState.CONNECTED)
+            # _on_event dispatches on a task, so let it run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert [event.state for event in seen] == [RealtimeConnectionState.CONNECTED]
+
+    @pytest.mark.asyncio
+    async def test_start_push_forwards_client_id_to_the_transport(self) -> None:
+        """A caller-supplied MQTT identifier must reach the transport."""
+        from actron_neo_api import actron as actron_module
+
+        class FakeMQTTClient:
+            def __init__(
+                self,
+                details: RealtimeConnectionDetails,
+                user_email: str,
+                token: str,
+                client_id: str | None = None,
+            ) -> None:
+                self.client_id = client_id
+
+            def register_callback(self, callback: Any) -> None:
+                return None
+
+            async def connect(self) -> None:
+                return None
+
+            async def subscribe_system(self, serial: str) -> None:
+                return None
+
+            async def disconnect(self) -> None:
+                return None
+
+        api = ActronAirAPI(platform="neo")
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.oauth2_auth.get_user_info = AsyncMock(return_value=None)
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        details = RealtimeConnectionDetails(
+            endpoint="mqtt.example.test", port=8883, protocol="ssl", user_id="u"
+        )
+
+        original_mqtt = actron_module.MQTTRTClient
+        try:
+            actron_module.MQTTRTClient = FakeMQTTClient  # type: ignore[assignment]
+            await api.start_push(connection_details=details, client_id="config-entry-1")
+        finally:
+            actron_module.MQTTRTClient = original_mqtt  # type: ignore[assignment]
+
+        assert isinstance(api._rt_client, FakeMQTTClient)
+        assert api._rt_client.client_id == "config-entry-1"

--- a/tests/test_actron.py
+++ b/tests/test_actron.py
@@ -1116,9 +1116,16 @@ class TestActronAirAPIRealtimeIntegration:
         """Que platform should use the SignalR transport."""
 
         class FakeSignalRClient:
-            def __init__(self, details: RealtimeConnectionDetails, token: str) -> None:
+            def __init__(
+                self,
+                details: RealtimeConnectionDetails,
+                token: str,
+                *,
+                session: Any = None,
+            ) -> None:
                 self.details = details
                 self.token = token
+                self.session = session
                 self.subscribed: list[str] = []
 
             def register_callback(self, callback: Any) -> None:
@@ -2747,3 +2754,60 @@ class TestActronAirAPIConnectionStateWiring:
 
         assert isinstance(api._rt_client, FakeMQTTClient)
         assert api._rt_client.client_id == "config-entry-1"
+
+
+class TestActronAirAPISessionInjection:
+    """The realtime transport must reuse the API's aiohttp session."""
+
+    @pytest.mark.asyncio
+    async def test_start_push_passes_injected_session_to_signalr(self) -> None:
+        """An injected session must cover the Que transport, not just HTTP calls.
+
+        Home Assistant injects its shared session; a transport that builds its
+        own would leave the inject-websession rule unsatisfied.
+        """
+        from actron_neo_api import actron as actron_module
+
+        class FakeSignalRClient:
+            def __init__(
+                self,
+                details: RealtimeConnectionDetails,
+                token: str,
+                *,
+                session: Any = None,
+            ) -> None:
+                self.session = session
+
+            def register_callback(self, callback: Any) -> None:
+                return None
+
+            async def connect(self) -> None:
+                return None
+
+            async def subscribe(self, serial: str) -> None:
+                return None
+
+            async def disconnect(self) -> None:
+                return None
+
+        injected = MagicMock()
+        injected.closed = False
+
+        api = ActronAirAPI(platform="que", session=injected)
+        api.oauth2_auth.ensure_token_valid = AsyncMock(return_value=None)
+        api.oauth2_auth.access_token = "token"
+        api.systems = [ActronAirSystemInfo(serial="abc123")]
+
+        details = RealtimeConnectionDetails(
+            endpoint="https://example.test/signalr", port=443, protocol="https", user_id="u"
+        )
+
+        original_signalr = actron_module.SignalRRTClient
+        try:
+            actron_module.SignalRRTClient = FakeSignalRClient  # type: ignore[assignment]
+            assert await api.start_push(connection_details=details) is True
+        finally:
+            actron_module.SignalRRTClient = original_signalr  # type: ignore[assignment]
+
+        assert isinstance(api._rt_client, FakeSignalRClient)
+        assert api._rt_client.session is injected

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -17,6 +17,7 @@ from actron_neo_api.rt import (
     RealtimeConnectionDetails,
     RealtimeConnectionEvent,
     RealtimeConnectionState,
+    RealtimeEvent,
     RealtimeEventKind,
     RealtimeMessage,
 )
@@ -1139,3 +1140,107 @@ class TestMQTTRTClient:
         assert client.last_error is not None
         assert isinstance(client.last_error, OSError)
         assert client.connection_state == RealtimeConnectionState.DISCONNECTED
+
+
+class TestMQTTRealtimeDispatch:
+    """Callback dispatch, queue retention and session identity."""
+
+    @staticmethod
+    def _client(**kwargs: object) -> MQTTRTClient:
+        return MQTTRTClient(
+            RealtimeConnectionDetails(
+                endpoint="mqtt.example.com",
+                port=8883,
+                protocol="ssl",
+                user_id="user-1",
+            ),
+            user_email="test@example.com",
+            access_token="token-123",
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_state_notifies_callbacks(self) -> None:
+        """Connection transitions must reach callback subscribers, not just the queue."""
+        client = self._client()
+        seen: list[RealtimeConnectionEvent] = []
+        client.register_callback(seen.append)  # type: ignore[arg-type]
+
+        await client._set_state(RealtimeConnectionState.RECONNECTING)  # noqa: SLF001
+        await client._set_state(RealtimeConnectionState.CONNECTED)  # noqa: SLF001
+
+        assert [event.state for event in seen] == [
+            RealtimeConnectionState.RECONNECTING,
+            RealtimeConnectionState.CONNECTED,
+        ]
+        assert seen[1].previous_state == RealtimeConnectionState.RECONNECTING
+        assert client._event_queue.qsize() == 2  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_set_state_survives_failing_callback(self) -> None:
+        """A raising subscriber must not propagate into the supervisor loop."""
+        client = self._client()
+
+        def _bad(_: RealtimeEvent) -> None:
+            raise ValueError("boom")
+
+        client.register_callback(_bad)
+
+        await client._set_state(RealtimeConnectionState.CONNECTED)  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_event_queue_is_bounded_without_a_consumer(self) -> None:
+        """Events must not accumulate for the life of the process."""
+        client = self._client(event_queue_maxsize=4)
+
+        for index in range(50):
+            await client._handle_message(  # noqa: SLF001
+                "actron-cloud/user-1/neo/abc/mwc/heart-beat",
+                json.dumps({"n": index}).encode(),
+            )
+
+        assert client._event_queue.qsize() == 4  # noqa: SLF001
+        retained = client._event_queue.get_nowait()  # noqa: SLF001
+        assert retained.payload == {"n": 46}  # type: ignore[union-attr]
+
+    def test_event_queue_maxsize_is_validated(self) -> None:
+        """A non-positive queue size is rejected."""
+        with pytest.raises(ValueError, match="event_queue_maxsize"):
+            self._client(event_queue_maxsize=0)
+
+    def test_generated_identifier_uses_a_clean_session(self) -> None:
+        """A random identifier must not claim a persistent broker session."""
+        client = self._client()
+
+        assert client._client_id.startswith("HA_")  # noqa: SLF001
+        assert client._clean_session is True  # noqa: SLF001
+
+    def test_supplied_identifier_keeps_a_persistent_session(self) -> None:
+        """A caller-supplied identifier is assumed stable across restarts."""
+        client = self._client(client_id="config-entry-1")
+
+        assert client._client_id == "config-entry-1"  # noqa: SLF001
+        assert client._clean_session is False  # noqa: SLF001
+
+    def test_blank_identifier_falls_back_to_a_generated_one(self) -> None:
+        """A blank identifier is treated as if none was supplied."""
+        client = self._client(client_id="   ")
+
+        assert client._client_id.startswith("HA_")  # noqa: SLF001
+        assert client._clean_session is True  # noqa: SLF001
+
+    def test_clean_session_flag_reaches_the_broker_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The session mode chosen from the identifier is what gets connected."""
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            mqtt_module, "Client", lambda **kwargs: captured.append(kwargs) or object()
+        )
+
+        self._client()._build_client()  # noqa: SLF001
+        self._client(client_id="config-entry-1")._build_client()  # noqa: SLF001
+
+        assert captured[0]["clean_session"] is True
+        assert captured[1]["clean_session"] is False
+        assert captured[1]["identifier"] == "config-entry-1"

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -8,7 +8,12 @@ from typing import Any
 import aiohttp
 import pytest
 
-from actron_neo_api.rt import RealtimeConnectionDetails, SignalRRTClient, signalr_client
+from actron_neo_api.rt import (
+    RealtimeConnectionDetails,
+    RealtimeConnectionState,
+    SignalRRTClient,
+    signalr_client,
+)
 from actron_neo_api.rt.base import (
     RealtimeEvent,
     RealtimeEventKind,
@@ -810,7 +815,7 @@ async def test_connect_and_listen_disables_total_timeout() -> None:
 
     timeout = session.get_calls[0]["timeout"]
     assert timeout.total is None
-    assert timeout.sock_read == 180.0
+    assert timeout.sock_read == 600.0
     assert timeout.sock_connect == 15.0
 
 
@@ -871,3 +876,108 @@ async def test_run_supervisor_resets_backoff_after_healthy_connection(
     await client._run_supervisor()
 
     assert slept == [0.25, 0.25]
+
+
+@pytest.mark.asyncio
+async def test_stream_read_timeout_is_configurable() -> None:
+    client = SignalRRTClient(_details(), access_token="secret", stream_read_timeout=None)
+    session = _Session(
+        post_responses=[_Response(status=200, json_data={"url": "https://example.test/sse"})],
+        get_responses=[_Response(status=200, content_items=[])],
+    )
+    client._session = session  # type: ignore[assignment]
+    client._running = True
+
+    await client._connect_and_listen()
+
+    assert session.get_calls[0]["timeout"].sock_read is None
+
+    with pytest.raises(ValueError, match="stream_read_timeout"):
+        SignalRRTClient(_details(), access_token="secret", stream_read_timeout=0)
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_ignores_sse_keepalive_comments() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    session = _Session(
+        post_responses=[_Response(status=200, json_data={"url": "https://example.test/sse"})],
+        get_responses=[
+            _Response(
+                status=200,
+                content_items=[
+                    b": ping\n",
+                    b'data: {"a": 1}\n',
+                    b"\n",
+                ],
+            )
+        ],
+    )
+    client._session = session  # type: ignore[assignment]
+    client._running = True
+    seen: list[RealtimeEvent] = []
+    client.register_callback(seen.append)
+
+    await client._connect_and_listen()
+    await asyncio.sleep(0)
+
+    # The keepalive is discarded rather than corrupting the buffered payload.
+    assert [ev.payload for ev in seen if isinstance(ev, RealtimeMessage)] == [{"a": 1}]
+
+
+@pytest.mark.asyncio
+async def test_set_state_notifies_callbacks() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    seen: list[RealtimeEvent] = []
+    client.register_callback(seen.append)
+
+    await client._set_state(RealtimeConnectionState.RECONNECTING)
+    await client._set_state(RealtimeConnectionState.CONNECTED)
+
+    assert [ev.state for ev in seen] == [  # type: ignore[union-attr]
+        RealtimeConnectionState.RECONNECTING,
+        RealtimeConnectionState.CONNECTED,
+    ]
+    assert client._events.qsize() == 2
+
+
+@pytest.mark.asyncio
+async def test_emit_event_awaits_async_callbacks() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    seen: list[RealtimeEvent] = []
+
+    async def _async_cb(ev: RealtimeEvent) -> None:
+        seen.append(ev)
+
+    client.register_callback(_async_cb)
+
+    await client._set_state(RealtimeConnectionState.CONNECTED)
+
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_set_state_survives_failing_callback() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+
+    def _bad(_: RealtimeEvent) -> None:
+        raise ValueError("boom")
+
+    client.register_callback(_bad)
+
+    # A failing subscriber must not propagate into the supervisor loop.
+    await client._set_state(RealtimeConnectionState.CONNECTED)
+
+
+@pytest.mark.asyncio
+async def test_event_queue_is_bounded_without_a_consumer() -> None:
+    client = SignalRRTClient(_details(), access_token="secret", event_queue_maxsize=4)
+
+    for index in range(50):
+        await client._emit_event(_message({"n": index}))
+
+    assert client._events.qsize() == 4
+    # The most recent events are the ones retained.
+    assert client._events.get_nowait().payload == {"n": 46}
+
+    with pytest.raises(ValueError, match="event_queue_maxsize"):
+        SignalRRTClient(_details(), access_token="secret", event_queue_maxsize=0)

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import aiohttp
@@ -981,3 +982,47 @@ async def test_event_queue_is_bounded_without_a_consumer() -> None:
 
     with pytest.raises(ValueError, match="event_queue_maxsize"):
         SignalRRTClient(_details(), access_token="secret", event_queue_maxsize=0)
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_reason"),
+    [
+        (aiohttp.ClientError("connection reset"), "connection reset"),
+        (OSError(), "OSError"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_supervisor_reports_transport_errors_without_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+    expected_reason: str,
+) -> None:
+    client = SignalRRTClient(
+        _details(),
+        access_token="secret",
+        reconnect_initial_delay=0.25,
+        reconnect_max_delay=1.0,
+    )
+    client._running = True
+
+    async def _connect_and_listen() -> None:
+        raise error
+
+    async def _sleep(delay: float) -> None:
+        client._running = False
+
+    client._connect_and_listen = _connect_and_listen  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+    with caplog.at_level(logging.DEBUG, logger="actron_neo_api.rt.signalr_client"):
+        await client._run_supervisor()
+
+    reasons = [
+        client._events.get_nowait().reason  # type: ignore[union-attr]
+        for _ in range(client._events.qsize())
+    ]
+    assert expected_reason in reasons
+    # Routine drops are debug-level; ERROR is reserved for the unexpected.
+    assert "SignalR reconnecting after error" in caplog.text
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]

--- a/tests/test_signalr_client.py
+++ b/tests/test_signalr_client.py
@@ -8,7 +8,7 @@ from typing import Any
 import aiohttp
 import pytest
 
-from actron_neo_api.rt import RealtimeConnectionDetails, SignalRRTClient
+from actron_neo_api.rt import RealtimeConnectionDetails, SignalRRTClient, signalr_client
 from actron_neo_api.rt.base import (
     RealtimeEvent,
     RealtimeEventKind,
@@ -794,3 +794,80 @@ async def test_handle_payload_outer_exception_path(monkeypatch: pytest.MonkeyPat
 
     # The method should swallow/log the failure and not raise.
     client._handle_payload({"a": 1})
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_disables_total_timeout() -> None:
+    client = SignalRRTClient(_details(), access_token="secret")
+    session = _Session(
+        post_responses=[_Response(status=200, json_data={"url": "https://example.test/sse"})],
+        get_responses=[_Response(status=200, content_items=[])],
+    )
+    client._session = session  # type: ignore[assignment]
+    client._running = True
+
+    await client._connect_and_listen()
+
+    timeout = session.get_calls[0]["timeout"]
+    assert timeout.total is None
+    assert timeout.sock_read == 180.0
+    assert timeout.sock_connect == 15.0
+
+
+@pytest.mark.asyncio
+async def test_run_supervisor_reports_stream_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SignalRRTClient(
+        _details(),
+        access_token="secret",
+        reconnect_initial_delay=0.25,
+        reconnect_max_delay=1.0,
+    )
+    client._running = True
+
+    async def _connect_and_listen() -> None:
+        raise asyncio.TimeoutError
+
+    async def _sleep(delay: float) -> None:
+        client._running = False
+
+    client._connect_and_listen = _connect_and_listen  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+    await client._run_supervisor()
+
+    reasons = [
+        client._events.get_nowait().reason  # type: ignore[union-attr]
+        for _ in range(client._events.qsize())
+    ]
+    assert "stream timeout" in reasons
+
+
+@pytest.mark.asyncio
+async def test_run_supervisor_resets_backoff_after_healthy_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SignalRRTClient(
+        _details(),
+        access_token="secret",
+        reconnect_initial_delay=0.25,
+        reconnect_max_delay=1.0,
+    )
+    client._running = True
+    calls = {"connect": 0}
+    slept: list[float] = []
+
+    async def _connect_and_listen() -> None:
+        calls["connect"] += 1
+        if calls["connect"] >= 3:
+            client._running = False
+
+    async def _sleep(delay: float) -> None:
+        slept.append(delay)
+
+    client._connect_and_listen = _connect_and_listen  # type: ignore[method-assign]
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    monkeypatch.setattr(signalr_client, "_HEALTHY_CONNECTION_SECONDS", 0.0)
+
+    await client._run_supervisor()
+
+    assert slept == [0.25, 0.25]


### PR DESCRIPTION
Addresses the four issues reported from wiring cloud push into the Home Assistant core `actron_air` integration.

## 1. Connection-state callbacks never fired (blocker)

Both transports built the `RealtimeConnectionEvent` in `_set_state` and then only enqueued it, so the chain `ActronAirAPI` relies on broke at the first hop:

```
_set_state → queue                                     ← stopped here
_emit_event → callbacks → _handle_realtime_event → _dispatch_connection_event
```

`_set_state` now dispatches through `_emit_event`, which both queues the event and notifies callbacks. The reproduction from the report prints `2` for both transports.

Also aligned the two `_emit_event` implementations: SignalR's discarded each callback's return value, so **async subscribers silently never ran**. It now awaits a coroutine result like the MQTT one, and logs a raising callback rather than letting it escape into the supervisor loop.

## 2. Unbounded event queues (blocker)

Both transport queues are now bounded (`event_queue_maxsize`, default 256) and drop the oldest entry when full, via a shared helper in `rt/base.py`. A late `iter_events()` consumer still sees recent events; the process no longer retains every event — payload, raw payload and parsed status — for its lifetime. Dropping rather than blocking also keeps a stalled consumer from stalling the transport.

`ActronAirAPI._push_status_queue` had no consumer anywhere and has been removed, along with the sentinel `stop_push` wrote to it. The per-subscriber `_push_stream_queues` it predates already covers `stream_system_updates()`.

## 3. SSE stream killed by the session's total timeout

The streaming GET now carries its own `ClientTimeout(total=None, ...)`, so it no longer inherits the session default (300s under HA's shared session, 30s under the library-owned one).

`sock_read` is exposed as `stream_read_timeout` and **defaults to 600s rather than the 300s I first considered**: whether the Que endpoint sends idle keepalives is still unestablished, and a value at or below the session default would reintroduce the very teardown this fixes. Pass `None` to disable it entirely.

To settle that question, SSE comment lines are now parsed explicitly and logged at debug — previously a `: ping` matched neither the `data:` branch nor the blank-line branch and vanished invisibly, so no log could reveal the keepalive interval. Once a capture confirms the interval, `stream_read_timeout` can be tightened against it.

Expected transport drops (`TimeoutError`, `ClientError`, `OSError`) now log at debug like the MQTT supervisor, leaving `exception()` for genuinely unexpected failures. The backoff also resets after a connection that stayed up at least a minute — the previous reset only ran while shutting down, so a long-lived connection that dropped resumed at whatever elevated delay an earlier failure had left behind.

## 4. `clean_session=False` with a randomised client id

A persistent broker session is only meaningful with a stable identifier, so the two settings are now chosen together: a caller-supplied `client_id` is assumed stable and keeps `clean_session=False`; a generated `HA_`-prefixed one uses a clean session. `start_push()` gained an optional `client_id` so a consumer can pass something durable, such as a config entry id:

```python
await api.start_push([serial], client_id=entry.entry_id)
```

## 5. Injected session not used by the Que transport

`start_push` constructed `SignalRRTClient` without a session, so the transport built its own `aiohttp.ClientSession` even when one had been injected into `ActronAirAPI` — leaving a consumer that supplies a shared session with a second, unmanaged one. The session is now passed through. The transport only closes a session it created itself, so an injected one still outlives `disconnect()`, and every request the transport makes carries its own timeout, so the session default never reaches the event stream (which is what issue 3 above depends on).

This unblocks the `inject-websession` quality-scale rule for the Home Assistant integration.

## Testing

New tests cover each issue, including an end-to-end one that drives a **real** `MQTTRTClient` through `start_push` to a `subscribe_connection_state` subscriber — faking the transport there is exactly what let this go unnoticed. All four connection-state tests were confirmed to fail against the pre-fix code.

588 tests pass; ruff, ruff format and mypy are clean. Issues 1, 2 and 4 are verified by tests; issue 3's five-minute survival still needs confirmation against a live Que account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
